### PR TITLE
Refactor component tests dummy props

### DIFF
--- a/app/config/tests.js
+++ b/app/config/tests.js
@@ -1,0 +1,11 @@
+// @flow
+
+export const dummyTranslatorProps = {
+  t: (key: ?string): string => key || 'string',
+  i18nLoadedAt: new Date('2018-04-01T22:15:00'),
+  i18n: {},
+};
+
+export const dummyRouterMatchProps = {
+  match: { params: {}, isExact: true, path: '', url: '' },
+};

--- a/app/core-components/navigation/tests/NavigationBar.test.js
+++ b/app/core-components/navigation/tests/NavigationBar.test.js
@@ -3,6 +3,7 @@
 
 import * as React from 'react';
 import { shallow } from 'enzyme';
+import { dummyTranslatorProps } from 'config/tests';
 
 import { PureNavigationBar } from '../NavigationBar';
 
@@ -11,9 +12,7 @@ describe(`NavigationBar`, (): void => {
   it(`renders without errors`, (): void => {
     const enzymeWrapper = shallow(
       <PureNavigationBar
-        t={(key: ?string): string => key || 'string'}
-        i18nLoadedAt={new Date()}
-        i18n={{}}
+        {...dummyTranslatorProps}
       />,
     );
     expect(enzymeWrapper.isEmptyRender()).toEqual(false);

--- a/app/modules/content-items/components/content-item-display/tests/PlainTextContentItemDisplay.test.js
+++ b/app/modules/content-items/components/content-item-display/tests/PlainTextContentItemDisplay.test.js
@@ -3,6 +3,7 @@
 
 import * as React from 'react';
 import { shallow } from 'enzyme';
+import { dummyTranslatorProps } from 'config/tests';
 
 import { PurePlainTextContentItemDisplay } from '../PlainTextContentItemDisplay';
 
@@ -25,10 +26,8 @@ describe(`PlainTextContentItemDisplay`, (): void => {
 
     const enzymeWrapper = shallow(
       <PurePlainTextContentItemDisplay
+        {...dummyTranslatorProps}
         contentItem={dummyContentItem}
-        t={(key: ?string): string => key || 'string'}
-        i18nLoadedAt={new Date()}
-        i18n={{}}
       />,
     );
     expect(enzymeWrapper.isEmptyRender()).toEqual(false);

--- a/app/modules/content-items/components/tests/EditorBlock.test.js
+++ b/app/modules/content-items/components/tests/EditorBlock.test.js
@@ -3,6 +3,7 @@
 
 import * as React from 'react';
 import { shallow } from 'enzyme';
+import { dummyTranslatorProps } from 'config/tests';
 
 import { PureEditorBlock } from '../EditorBlock';
 
@@ -13,11 +14,9 @@ describe(`EditorBlock`, (): void => {
   it(`renders without errors`, (): void => {
     const enzymeWrapper = shallow(
       <PureEditorBlock
+        {...dummyTranslatorProps}
         contentItemId="abcdefghij"
         contentItem={{ id: 'abcdefghij', type: contentItemTypes.ROOT, childItemIds: [] }}
-        t={(key: ?string): string => key || 'string'}
-        i18nLoadedAt={new Date()}
-        i18n={{}}
       />,
     );
     expect(enzymeWrapper.isEmptyRender()).toEqual(false);

--- a/app/modules/content-items/components/tests/EditorRoot.test.js
+++ b/app/modules/content-items/components/tests/EditorRoot.test.js
@@ -3,6 +3,7 @@
 
 import * as React from 'react';
 import { shallow } from 'enzyme';
+import { dummyTranslatorProps } from 'config/tests';
 
 import { PureEditorRoot } from '../EditorRoot';
 
@@ -13,11 +14,9 @@ describe(`EditorRoot`, (): void => {
   it(`renders without errors`, (): void => {
     const enzymeWrapper = shallow(
       <PureEditorRoot
+        {...dummyTranslatorProps}
         rootContentItemId=""
         rootContentItem={{ id: 'abcdefghij', type: contentItemTypes.ROOT, childItemIds: [] }}
-        t={(key: ?string): string => key || 'string'}
-        i18nLoadedAt={new Date()}
-        i18n={{}}
       />,
     );
     expect(enzymeWrapper.isEmptyRender()).toEqual(false);

--- a/app/modules/topics/components/tests/Editor.test.js
+++ b/app/modules/topics/components/tests/Editor.test.js
@@ -3,6 +3,7 @@
 
 import * as React from 'react';
 import { shallow } from 'enzyme';
+import { dummyTranslatorProps } from 'config/tests';
 
 import { PureEditor } from '../Editor';
 
@@ -18,11 +19,9 @@ describe(`List`, (): void => {
 
     const enzymeWrapper = shallow(
       <PureEditor
+        {...dummyTranslatorProps}
         topicId="abcdefghij"
         topic={dummyTopic}
-        t={(key: ?string): string => key || 'string'}
-        i18nLoadedAt={new Date()}
-        i18n={{}}
       />,
     );
     expect(enzymeWrapper.isEmptyRender()).toEqual(false);

--- a/app/modules/topics/components/tests/List.test.js
+++ b/app/modules/topics/components/tests/List.test.js
@@ -3,6 +3,7 @@
 
 import * as React from 'react';
 import { shallow } from 'enzyme';
+import { dummyTranslatorProps } from 'config/tests';
 
 import { PureList } from '../List';
 
@@ -11,14 +12,12 @@ describe(`List`, (): void => {
   it(`renders without errors`, (): void => {
     const enzymeWrapper = shallow(
       <PureList
+        {...dummyTranslatorProps}
         topicIds={[]}
         lastTopicId="abcde"
         onAddButtonClick={(): void => {}}
         onEditButtonClick={(): void => {}}
         onRemoveButtonClick={(): void => {}}
-        t={(key: ?string): string => key || 'string'}
-        i18nLoadedAt={new Date()}
-        i18n={{}}
       />,
     );
     expect(enzymeWrapper.isEmptyRender()).toEqual(false);

--- a/app/modules/topics/components/tests/Preview.test.js
+++ b/app/modules/topics/components/tests/Preview.test.js
@@ -3,6 +3,7 @@
 
 import * as React from 'react';
 import { shallow } from 'enzyme';
+import { dummyTranslatorProps } from 'config/tests';
 
 import { PurePreview } from '../Preview';
 
@@ -18,11 +19,9 @@ describe(`Preview`, (): void => {
 
     const enzymeWrapper = shallow(
       <PurePreview
+        {...dummyTranslatorProps}
         topicId="abcdefghij"
         topic={dummyTopic}
-        t={(key: ?string): string => key || 'string'}
-        i18nLoadedAt={new Date()}
-        i18n={{}}
       />,
     );
     expect(enzymeWrapper.isEmptyRender()).toEqual(false);

--- a/app/pages/components/tests/EditorPage.test.js
+++ b/app/pages/components/tests/EditorPage.test.js
@@ -3,6 +3,7 @@
 
 import * as React from 'react';
 import { shallow } from 'enzyme';
+import { dummyTranslatorProps, dummyRouterMatchProps } from 'config/tests';
 
 import { PureEditorPage } from '../EditorPage';
 
@@ -11,10 +12,8 @@ describe(`EditorPage`, (): void => {
   it(`renders without errors`, (): void => {
     const enzymeWrapper = shallow(
       <PureEditorPage
-        t={(key: ?string): string => key || 'string'}
-        i18nLoadedAt={new Date()}
-        i18n={{}}
-        match={{ params: {}, isExact: true, path: '', url: '' }}
+        {...dummyTranslatorProps}
+        {...dummyRouterMatchProps}
       />,
     );
     expect(enzymeWrapper.isEmptyRender()).toEqual(false);

--- a/app/pages/components/tests/HomePage.test.js
+++ b/app/pages/components/tests/HomePage.test.js
@@ -3,6 +3,7 @@
 
 import * as React from 'react';
 import { shallow } from 'enzyme';
+import { dummyTranslatorProps } from 'config/tests';
 
 import { PureHomePage } from '../HomePage';
 
@@ -11,10 +12,8 @@ describe(`HomePage`, (): void => {
   it(`renders without errors`, (): void => {
     const enzymeWrapper = shallow(
       <PureHomePage
+        {...dummyTranslatorProps}
         feedItemIds={[]}
-        t={(key: ?string): string => key || 'string'}
-        i18nLoadedAt={new Date()}
-        i18n={{}}
       />,
     );
     expect(enzymeWrapper.isEmptyRender()).toEqual(false);

--- a/app/pages/components/tests/LibraryPage.test.js
+++ b/app/pages/components/tests/LibraryPage.test.js
@@ -3,6 +3,7 @@
 
 import * as React from 'react';
 import { shallow } from 'enzyme';
+import { dummyTranslatorProps } from 'config/tests';
 
 import { PureLibraryPage } from '../LibraryPage';
 
@@ -11,9 +12,7 @@ describe(`LibraryPage`, (): void => {
   it(`renders without errors`, (): void => {
     const enzymeWrapper = shallow(
       <PureLibraryPage
-        t={(key: ?string): string => key || 'string'}
-        i18nLoadedAt={new Date()}
-        i18n={{}}
+        {...dummyTranslatorProps}
       />,
     );
     expect(enzymeWrapper.isEmptyRender()).toEqual(false);

--- a/app/pages/components/tests/NewTopicPage.test.js
+++ b/app/pages/components/tests/NewTopicPage.test.js
@@ -3,6 +3,7 @@
 
 import * as React from 'react';
 import { shallow } from 'enzyme';
+import { dummyTranslatorProps } from 'config/tests';
 
 import { PureNewTopicPage } from '../NewTopicPage';
 
@@ -11,10 +12,8 @@ describe(`NewTopicPage`, (): void => {
   it(`renders without errors`, (): void => {
     const enzymeWrapper = shallow(
       <PureNewTopicPage
+        {...dummyTranslatorProps}
         topicIds={[]}
-        t={(key: ?string): string => key || 'string'}
-        i18nLoadedAt={new Date()}
-        i18n={{}}
       />,
     );
     expect(enzymeWrapper.isEmptyRender()).toEqual(false);

--- a/app/pages/components/tests/NotFoundPage.test.js
+++ b/app/pages/components/tests/NotFoundPage.test.js
@@ -3,6 +3,7 @@
 
 import * as React from 'react';
 import { shallow } from 'enzyme';
+import { dummyTranslatorProps } from 'config/tests';
 
 import { PureNotFoundPage } from '../NotFoundPage';
 
@@ -11,9 +12,7 @@ describe(`NotFoundPage`, (): void => {
   it(`renders without errors`, (): void => {
     const enzymeWrapper = shallow(
       <PureNotFoundPage
-        t={(key: ?string): string => key || 'string'}
-        i18nLoadedAt={new Date()}
-        i18n={{}}
+        {...dummyTranslatorProps}
       />,
     );
     expect(enzymeWrapper.isEmptyRender()).toEqual(false);

--- a/app/pages/components/tests/TopicsPage.test.js
+++ b/app/pages/components/tests/TopicsPage.test.js
@@ -3,6 +3,7 @@
 
 import * as React from 'react';
 import { shallow } from 'enzyme';
+import { dummyTranslatorProps } from 'config/tests';
 
 import { PureTopicsPage } from '../TopicsPage';
 
@@ -11,10 +12,8 @@ describe(`TopicsPage`, (): void => {
   it(`renders without errors`, (): void => {
     const enzymeWrapper = shallow(
       <PureTopicsPage
+        {...dummyTranslatorProps}
         topicIds={[]}
-        t={(key: ?string): string => key || 'string'}
-        i18nLoadedAt={new Date()}
-        i18n={{}}
       />,
     );
     expect(enzymeWrapper.isEmptyRender()).toEqual(false);


### PR DESCRIPTION
Added tests config file with dummy props so these don't have to be copy/pasted into every React component test; updated existing tests to use config file instead of copy/pasted props.