### PR TITLE
fetch user's email if it is missing in Event

### DIFF
--- a/app/lib/api/apis/users.js
+++ b/app/lib/api/apis/users.js
@@ -9,13 +9,14 @@ import ApiRequest from '../ApiRequest';
 
 import { USERS_ENDPOINT } from './constants';
 
-const get = (id: Identifier): Promise<Response> => {
+const get = (id: Identifier, token: ?string): Promise<Response> => {
   const request = new ApiRequest();
 
   request
     .setEndpoint(USERS_ENDPOINT)
     .setMethod(methodTypes.GET)
-    .setResource(id);
+    .setResource(id)
+    .setToken(token);
 
   return request.execute();
 };

--- a/app/modules/feed/components/Event.js
+++ b/app/modules/feed/components/Event.js
@@ -87,7 +87,7 @@ class PureEventWrapper extends React.Component<Props, State> {
       getTopic(event.topicId);
     }
 
-    if (user == null) {
+    if (user == null || user.email === '') {
       getUser(event.userId);
     }
   };

--- a/app/modules/users/saga/api/tests/users.test.js
+++ b/app/modules/users/saga/api/tests/users.test.js
@@ -30,8 +30,7 @@ describe(`users`, (): void => {
       });
     };
 
-    // $FlowFixMe
-    selectors.getToken = (): string => {
+    (selectors: any).getToken = (): string => {
       return 'foobartoken';
     };
   });

--- a/app/modules/users/saga/api/tests/users.test.js
+++ b/app/modules/users/saga/api/tests/users.test.js
@@ -5,6 +5,8 @@ import { expectSaga } from 'redux-saga-test-plan';
 import { UsersApi } from 'lib/api';
 import type { Response } from 'lib/api';
 
+import * as selectors from 'modules/authentication/selectors';
+
 import * as t from '../../../actionTypes';
 import { apiGetUserSaga } from '../users';
 
@@ -15,17 +17,22 @@ describe(`users`, (): void => {
       return Promise.resolve({
         body: {
           data: {
+            id: '0',
             attributes: {
-              id: '0',
-              email: 'foo@bar',
               firstName: 'Foo',
               lastName: 'Bar',
+              email: 'foo@bar',
             },
           },
         },
-        token: null,
+        token: 'foobartoken',
         status: 200,
       });
+    };
+
+    // $FlowFixMe
+    selectors.getToken = (): string => {
+      return 'foobartoken';
     };
   });
 
@@ -39,7 +46,8 @@ describe(`users`, (): void => {
       };
 
       return expectSaga(apiGetUserSaga, dummyGetUsersAction)
-        .call(UsersApi.get, '0')
+        .call(UsersApi.get, '0', 'foobartoken')
+        .put.like({ action: { type: t.ADD_TO_STATE } })
         .run();
     });
   });

--- a/app/modules/users/saga/api/users.js
+++ b/app/modules/users/saga/api/users.js
@@ -2,17 +2,15 @@
 
 import { call, put, select } from 'redux-saga/effects';
 import { UsersApi } from 'lib/api';
+import authentication from 'modules/authentication';
 
 import * as t from '../../actionTypes';
-
 import { addToState } from '../../actions';
-
-import { getToken } from '../../../authentication/selectors';
 
 export const apiGetUserSaga = function* (action: t.ApiGetUserAction): Generator<*, *, *> {
   try {
     const { id } = action.payload;
-    const token = yield select(getToken);
+    const token = yield select(authentication.selectors.getToken);
 
     const response = yield call(UsersApi.get, id, token);
     const { attributes } = response.body.data;

--- a/app/modules/users/saga/api/users.js
+++ b/app/modules/users/saga/api/users.js
@@ -1,17 +1,20 @@
 // @flow
 
-import { call, put } from 'redux-saga/effects';
-
+import { call, put, select } from 'redux-saga/effects';
 import { UsersApi } from 'lib/api';
 
 import * as t from '../../actionTypes';
 
 import { addToState } from '../../actions';
 
+import { getToken } from '../../../authentication/selectors';
+
 export const apiGetUserSaga = function* (action: t.ApiGetUserAction): Generator<*, *, *> {
   try {
     const { id } = action.payload;
-    const response = yield call(UsersApi.get, id);
+    const token = yield select(getToken);
+
+    const response = yield call(UsersApi.get, id, token);
     const { attributes } = response.body.data;
 
     yield put(addToState(


### PR DESCRIPTION
Kinda solves #75. Couldn't find a way to invalidate users only once, right after signing in, so now it fetches the email of a user if it's missing.

Issues:
 - backend only returns email of authenticated user

