### PR TITLE
Fix jest coverage report

### DIFF
--- a/app/errors/ApiError.js
+++ b/app/errors/ApiError.js
@@ -10,6 +10,14 @@ class ApiError extends CustomError {
   // translator keys.
   constructor(message: string, isTranslatable: boolean = false): void {
     super(message, isTranslatable);
+
+    // Temporary workaround for https://github.com/istanbuljs/babel-plugin-istanbul/issues/143 #TODO
+    /* eslint-disable no-proto */
+    // $FlowFixMe
+    this.constructor = ApiError;
+    // $FlowFixMe
+    this.__proto__ = ApiError.prototype;
+    /* eslint-enable */
   }
 }
 

--- a/app/errors/CustomError.js
+++ b/app/errors/CustomError.js
@@ -20,6 +20,14 @@ class CustomError extends Error {
     else newMessage = message;
 
     super(newMessage);
+
+    // Temporary workaround for https://github.com/istanbuljs/babel-plugin-istanbul/issues/143 #TODO
+    /* eslint-disable no-proto */
+    // $FlowFixMe
+    this.constructor = CustomError;
+    // $FlowFixMe
+    this.__proto__ = CustomError.prototype;
+    /* eslint-enable */
   }
 }
 

--- a/app/errors/ImplementationError.js
+++ b/app/errors/ImplementationError.js
@@ -10,6 +10,14 @@ class ImplementationError extends CustomError {
   // and should not be shown to the user.
   constructor(message: string, isTranslatable: boolean = false): void {
     super(message, isTranslatable);
+
+    // Temporary workaround for https://github.com/istanbuljs/babel-plugin-istanbul/issues/143 #TODO
+    /* eslint-disable no-proto */
+    // $FlowFixMe
+    this.constructor = ImplementationError;
+    // $FlowFixMe
+    this.__proto__ = ImplementationError.prototype;
+    /* eslint-enable */
   }
 }
 

--- a/app/errors/UsageError.js
+++ b/app/errors/UsageError.js
@@ -10,6 +10,14 @@ class UsageError extends CustomError {
   // However, subclasses might use custom translation logic and then set the default to FALSE.
   constructor(message: string, isTranslatable: boolean = true): void {
     super(message, isTranslatable);
+
+    // Temporary workaround for https://github.com/istanbuljs/babel-plugin-istanbul/issues/143 #TODO
+    /* eslint-disable no-proto */
+    // $FlowFixMe
+    this.constructor = UsageError;
+    // $FlowFixMe
+    this.__proto__ = UsageError.prototype;
+    /* eslint-enable */
   }
 }
 

--- a/app/errors/api-errors/ForbiddenError.js
+++ b/app/errors/api-errors/ForbiddenError.js
@@ -8,6 +8,14 @@ import ApiError from '../ApiError';
 class ForbiddenError extends ApiError {
   constructor(): void {
     super('Forbidden');
+
+    // Temporary workaround for https://github.com/istanbuljs/babel-plugin-istanbul/issues/143 #TODO
+    /* eslint-disable no-proto */
+    // $FlowFixMe
+    this.constructor = ForbiddenError;
+    // $FlowFixMe
+    this.__proto__ = ForbiddenError.prototype;
+    /* eslint-enable */
   }
 }
 

--- a/app/errors/api-errors/ServerError.js
+++ b/app/errors/api-errors/ServerError.js
@@ -5,6 +5,18 @@
 
 import ApiError from '../ApiError';
 
-class ServerError extends ApiError {}
+class ServerError extends ApiError {
+  constructor(message: string, isTranslatable: boolean = false): void {
+    super(message, isTranslatable);
+
+    // Temporary workaround for https://github.com/istanbuljs/babel-plugin-istanbul/issues/143 #TODO
+    /* eslint-disable no-proto */
+    // $FlowFixMe
+    this.constructor = ServerError;
+    // $FlowFixMe
+    this.__proto__ = ServerError.prototype;
+    /* eslint-enable */
+  }
+}
 
 export default ServerError;

--- a/app/errors/api-errors/UnauthorizedError.js
+++ b/app/errors/api-errors/UnauthorizedError.js
@@ -8,6 +8,14 @@ import ApiError from '../ApiError';
 class UnauthorizedError extends ApiError {
   constructor(): void {
     super('Unauthorized');
+
+    // Temporary workaround for https://github.com/istanbuljs/babel-plugin-istanbul/issues/143 #TODO
+    /* eslint-disable no-proto */
+    // $FlowFixMe
+    this.constructor = UnauthorizedError;
+    // $FlowFixMe
+    this.__proto__ = UnauthorizedError.prototype;
+    /* eslint-enable */
   }
 }
 

--- a/app/errors/api-errors/ValidationError.js
+++ b/app/errors/api-errors/ValidationError.js
@@ -7,6 +7,17 @@ import ApiError from '../ApiError';
 
 class ValidationError extends ApiError {
   // TODO: proper structure for JSONAPI validation errors
+  constructor(message: string, isTranslatable: boolean = false): void {
+    super(message, isTranslatable);
+
+    // Temporary workaround for https://github.com/istanbuljs/babel-plugin-istanbul/issues/143 #TODO
+    /* eslint-disable no-proto */
+    // $FlowFixMe
+    this.constructor = ValidationError;
+    // $FlowFixMe
+    this.__proto__ = ValidationError.prototype;
+    /* eslint-enable */
+  }
 }
 
 export default ValidationError;

--- a/app/errors/implementation-errors/CorruptedInternalStateError.js
+++ b/app/errors/implementation-errors/CorruptedInternalStateError.js
@@ -1,22 +1,23 @@
 // @flow
+
 /**
- * An error caused by a developer attempting to use functionality in a way that was not intended.
+ * An error caused by the internal state of the application having become corrupted somehow.
  */
 
 import ImplementationError from '../ImplementationError';
 
-class UnsupportedOperationError extends ImplementationError {
+class CorruptedInternalStateError extends ImplementationError {
   constructor(message: string, isTranslatable: boolean = false): void {
     super(message, isTranslatable);
 
     // Temporary workaround for https://github.com/istanbuljs/babel-plugin-istanbul/issues/143 #TODO
     /* eslint-disable no-proto */
     // $FlowFixMe
-    this.constructor = UnsupportedOperationError;
+    this.constructor = CorruptedInternalStateError;
     // $FlowFixMe
-    this.__proto__ = UnsupportedOperationError.prototype;
+    this.__proto__ = CorruptedInternalStateError.prototype;
     /* eslint-enable */
   }
 }
 
-export default UnsupportedOperationError;
+export default CorruptedInternalStateError;

--- a/app/errors/implementation-errors/InvalidArgumentError.js
+++ b/app/errors/implementation-errors/InvalidArgumentError.js
@@ -5,6 +5,18 @@
 
 import ImplementationError from '../ImplementationError';
 
-class InvalidArgumentError extends ImplementationError {}
+class InvalidArgumentError extends ImplementationError {
+  constructor(message: string, isTranslatable: boolean = false): void {
+    super(message, isTranslatable);
+
+    // Temporary workaround for https://github.com/istanbuljs/babel-plugin-istanbul/issues/143 #TODO
+    /* eslint-disable no-proto */
+    // $FlowFixMe
+    this.constructor = InvalidArgumentError;
+    // $FlowFixMe
+    this.__proto__ = InvalidArgumentError.prototype;
+    /* eslint-enable */
+  }
+}
 
 export default InvalidArgumentError;

--- a/app/errors/implementation-errors/NotYetImplementedError.js
+++ b/app/errors/implementation-errors/NotYetImplementedError.js
@@ -20,6 +20,14 @@ class NotYetImplementedError extends ImplementationError {
     }
 
     super(newMessage, newIsTranslatable);
+
+    // Temporary workaround for https://github.com/istanbuljs/babel-plugin-istanbul/issues/143 #TODO
+    /* eslint-disable no-proto */
+    // $FlowFixMe
+    this.constructor = NotYetImplementedError;
+    // $FlowFixMe
+    this.__proto__ = NotYetImplementedError.prototype;
+    /* eslint-enable */
   }
 }
 

--- a/app/errors/usage-errors/ObjectNotFoundError.js
+++ b/app/errors/usage-errors/ObjectNotFoundError.js
@@ -18,6 +18,14 @@ class ObjectNotFoundError extends UsageError {
     const objectName = i18next.t(objectNameKey);
     const message = i18next.t('errors:usage.notFound', { objectName, objectId });
     super(message, false);
+
+    // Temporary workaround for https://github.com/istanbuljs/babel-plugin-istanbul/issues/143 #TODO
+    /* eslint-disable no-proto */
+    // $FlowFixMe
+    this.constructor = ObjectNotFoundError;
+    // $FlowFixMe
+    this.__proto__ = ObjectNotFoundError.prototype;
+    /* eslint-enable */
   }
 }
 


### PR DESCRIPTION
Applied temporary workaround for issue where `jest --coverage` would incorrectly fail tests containing `expect(...).toThrow(CustomError)` because of a bug in instanbul / babel-plugin-transform-builtin-extend. See https://github.com/istanbuljs/babel-plugin-istanbul/issues/143