### PR TITLE
Feature slide splitting

### DIFF
--- a/app/assets/stylesheets/custom/ows_slide.less
+++ b/app/assets/stylesheets/custom/ows_slide.less
@@ -2,26 +2,48 @@
            .ows_slide
 *******************************/
 
+.ows_slides {
+  margin-left: auto;
+  margin-right: auto;
+
+
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+
+  &__container {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+
+    /* justify-content: space-between; */
+
+    width: 100%;
+  }
+}
+
 .ows_slide {
   @number-of-plain-text-lines-on-slide: 12;
   @slide-base-line-height: 1.8;
   @slide-ratio-v: 2;
   @slide-ratio-h: 3;
   @slide-padding: 2em;
+  @slide-margin: 1.25em;
 
   @slide-height: (@number-of-plain-text-lines-on-slide * @slide-base-line-height * 1em) + (@slide-padding * 2);
   @slide-width: @slide-height * @slide-ratio-h / @slide-ratio-v;
+
+  margin: @slide-margin;
 
   &__size {
     height: @slide-height;
     width: @slide-width;
     overflow-y: auto;
 
-    margin-left: auto;
-    margin-right: auto;
-
     border: 1px solid gray;
     line-height: @slide-base-line-height;
+
+    background: white;
   }
 
   &__content {

--- a/app/assets/stylesheets/custom/ows_slide.less
+++ b/app/assets/stylesheets/custom/ows_slide.less
@@ -2,24 +2,10 @@
            .ows_slide
 *******************************/
 
-.ows_slides {
-  margin-left: auto;
-  margin-right: auto;
-
-
+.ows_slides_container {
   display: flex;
-  justify-content: space-between;
+  flex-direction: row;
   flex-wrap: wrap;
-
-  &__container {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-
-    /* justify-content: space-between; */
-
-    width: 100%;
-  }
 }
 
 .ows_slide {

--- a/app/core-components/slides/Slide.js
+++ b/app/core-components/slides/Slide.js
@@ -5,11 +5,11 @@ import { translate } from 'react-i18next';
 import type { CustomTranslatorProps } from 'types/translator';
 
 import contentItems from 'modules/content-items';
-import type { DenormalizedRootContentItem } from 'modules/content-items';
+import type { DenormalizedContentItem } from 'modules/content-items';
 
 type PassedProps = {
-  // A denormalized ROOT item containing the content to be displayed on this slide.
-  contentItemTreeRootItem: DenormalizedRootContentItem,
+  // A denormalized content item containing the content to be displayed on this slide.
+  contentItem: DenormalizedContentItem,
   // The heading level of the top level headings on the slide. Defaults to 1.
   rootHeadingLevel: number,
 };
@@ -19,14 +19,14 @@ type Props = CustomTranslatorProps & PassedProps;
 const ContentItemHtmlDisplay = contentItems.components.HtmlDisplay;
 
 const PureSlide = (props: Props): React.Node => {
-  const { contentItemTreeRootItem, rootHeadingLevel } = props;
+  const { contentItem, rootHeadingLevel } = props;
 
   return (
     <div className="ows_slide">
       <div className="ows_slide__size">
         <div className="ows_slide__content">
           <ContentItemHtmlDisplay
-            contentItem={contentItemTreeRootItem}
+            contentItem={contentItem}
             headingLevel={rootHeadingLevel}
           />
         </div>

--- a/app/core-components/slides/Slides.js
+++ b/app/core-components/slides/Slides.js
@@ -4,7 +4,12 @@ import * as React from 'react';
 import { translate } from 'react-i18next';
 import type { CustomTranslatorProps } from 'types/translator';
 
-import type { DenormalizedRootContentItem } from 'modules/content-items';
+import type {
+  DenormalizedRootContentItem,
+  ContentItem,
+} from 'modules/content-items';
+
+import split from 'lib/content-item-split';
 
 import Slide from './Slide';
 
@@ -18,9 +23,15 @@ type Props = CustomTranslatorProps & PassedProps;
 const PureSlides = (props: Props): React.Node => {
   const { contentItemTreeRootItem } = props;
 
+  const contentItems: Array<ContentItem> = split(contentItemTreeRootItem);
+
   return (
     <div className="ows_slides">
-      <Slide contentItemTreeRootItem={contentItemTreeRootItem} />
+      {
+        contentItems.map((contentItem) => (
+          <Slide key={contentItem.id} contentItem={contentItem} />
+        ))
+      }
     </div>
   );
 };

--- a/app/core-components/slides/Slides.js
+++ b/app/core-components/slides/Slides.js
@@ -1,0 +1,31 @@
+// @flow
+
+import * as React from 'react';
+import { translate } from 'react-i18next';
+import type { CustomTranslatorProps } from 'types/translator';
+
+import type { DenormalizedRootContentItem } from 'modules/content-items';
+
+import Slide from './Slide';
+
+type PassedProps = {
+  // A denormalized ROOT item containing the content to be displayed on this slide.
+  contentItemTreeRootItem: DenormalizedRootContentItem,
+};
+
+type Props = CustomTranslatorProps & PassedProps;
+
+const PureSlides = (props: Props): React.Node => {
+  const { contentItemTreeRootItem } = props;
+
+  return (
+    <div className="ows_slides">
+      <Slide contentItemTreeRootItem={contentItemTreeRootItem} />
+    </div>
+  );
+};
+
+const Slides = translate()(PureSlides);
+
+export { PureSlides };
+export default Slides;

--- a/app/core-components/slides/Slides.js
+++ b/app/core-components/slides/Slides.js
@@ -6,7 +6,7 @@ import type { CustomTranslatorProps } from 'types/translator';
 
 import type {
   DenormalizedRootContentItem,
-  ContentItem,
+  DenormalizedContentItem,
 } from 'modules/content-items';
 
 import split from 'lib/content-item-split';
@@ -23,7 +23,7 @@ type Props = CustomTranslatorProps & PassedProps;
 const PureSlides = (props: Props): React.Node => {
   const { contentItemTreeRootItem } = props;
 
-  const contentItems: Array<ContentItem> = split(contentItemTreeRootItem);
+  const contentItems: Array<DenormalizedContentItem> = split(contentItemTreeRootItem);
 
   return (
     <div className="ows_slides">

--- a/app/core-components/slides/Slides.js
+++ b/app/core-components/slides/Slides.js
@@ -27,11 +27,13 @@ const PureSlides = (props: Props): React.Node => {
 
   return (
     <div className="ows_slides">
-      {
-        contentItems.map((contentItem) => (
-          <Slide key={contentItem.id} contentItem={contentItem} />
-        ))
-      }
+      <div className="ows_slides__container">
+        {
+          contentItems.map((contentItem) => (
+            <Slide key={contentItem.id} contentItem={contentItem} />
+          ))
+        }
+      </div>
     </div>
   );
 };

--- a/app/core-components/slides/Slides.js
+++ b/app/core-components/slides/Slides.js
@@ -26,14 +26,12 @@ const PureSlides = (props: Props): React.Node => {
   const contentItems: Array<DenormalizedContentItem> = split(contentItemTreeRootItem);
 
   return (
-    <div className="ows_slides">
-      <div className="ows_slides__container">
-        {
-          contentItems.map((contentItem) => (
-            <Slide key={contentItem.id} contentItem={contentItem} />
-          ))
-        }
-      </div>
+    <div className="ows_slides_container">
+      {
+        contentItems.map((contentItem) => (
+          <Slide key={contentItem.id} contentItem={contentItem} />
+        ))
+      }
     </div>
   );
 };

--- a/app/core-components/slides/tests/Slide.test.js
+++ b/app/core-components/slides/tests/Slide.test.js
@@ -4,24 +4,30 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { dummyTranslatorProps } from 'config/tests';
 
-import * as contentItems from 'modules/content-items';
+import contentItems from 'modules/content-items';
 
 import { PureSlide } from '../Slide';
+
+const { contentItemTypes } = contentItems.model;
 
 describe(`Slide`, (): void => {
 
   it(`renders without errors`, (): void => {
-    const dummyContentItemTreeRoot = {
+    const dummyContentItem = {
       id: 'abcdefghij',
-      type: contentItems.contentItemTypes.ROOT,
-      childItemIds: [],
-      childItems: [],
+      type: contentItemTypes.HEADING,
+      text: 'Heading',
+      metadata: {
+        tags: [],
+        visibilityOverrides: {},
+      },
+      subItems: [],
     };
 
     const enzymeWrapper = shallow(
       <PureSlide
         {...dummyTranslatorProps}
-        contentItemTreeRootItem={dummyContentItemTreeRoot}
+        contentItem={dummyContentItem}
       />,
     );
     expect(enzymeWrapper.isEmptyRender()).toEqual(false);

--- a/app/core-components/slides/tests/Slides.test.js
+++ b/app/core-components/slides/tests/Slides.test.js
@@ -1,0 +1,30 @@
+// @flow
+
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { dummyTranslatorProps } from 'config/tests';
+
+import * as contentItems from 'modules/content-items';
+
+import { PureSlides } from '../Slides';
+
+describe(`Slides`, (): void => {
+
+  it(`renders without errors`, (): void => {
+    const dummyContentItemTreeRoot = {
+      id: 'abcdefghij',
+      type: contentItems.contentItemTypes.ROOT,
+      childItemIds: [],
+      childItems: [],
+    };
+
+    const enzymeWrapper = shallow(
+      <PureSlides
+        {...dummyTranslatorProps}
+        contentItemTreeRootItem={dummyContentItemTreeRoot}
+      />,
+    );
+    expect(enzymeWrapper.isEmptyRender()).toEqual(false);
+  });
+
+});

--- a/app/lib/content-item-split/dummyData.js
+++ b/app/lib/content-item-split/dummyData.js
@@ -1,0 +1,165 @@
+// @flow
+
+import type {
+  DenormalizedHeadingContentItem,
+  DenormalizedParagraphContentItem,
+  DenormalizedRootContentItem,
+} from 'modules/content-items';
+
+import { contentItemTypes } from 'modules/content-items/model';
+
+// Paragraphs
+export const dummyParagraphContentItem1: DenormalizedParagraphContentItem = {
+  id: 'guweco5ijd',
+  type: contentItemTypes.PARAGRAPH,
+  text: 'Paragraph',
+  metadata: {
+    tags: [],
+    visibilityOverrides: {},
+  },
+  subItemIds: ['3yfivbpo4v'],
+  subItems: [{
+    id: '3yfivbpo4v',
+    type: contentItemTypes.PARAGRAPH,
+    text: 'Paragraph 2',
+    metadata: {
+      tags: [],
+      visibilityOverrides: {},
+    },
+    subItemIds: [],
+    subItems: [],
+  }],
+};
+
+// Subheadings
+export const dummySubHeadingContentItem1: DenormalizedHeadingContentItem = {
+  id: 'odo8vj3ivu',
+  type: contentItemTypes.HEADING,
+  text: 'Subheading 1',
+  metadata: {
+    tags: [],
+    visibilityOverrides: {},
+  },
+  subItemIds: [],
+  subItems: [],
+};
+
+export const dummySubHeadingContentItem2: DenormalizedHeadingContentItem = {
+  id: 'qocj4o9vco',
+  type: contentItemTypes.HEADING,
+  text: 'Subheading 2',
+  metadata: {
+    tags: [],
+    visibilityOverrides: {},
+  },
+  subItemIds: [],
+  subItems: [],
+};
+
+// Headings
+export const dummyHeadingContentItem1: DenormalizedHeadingContentItem = {
+  id: 'ko3ucudn9l',
+  type: contentItemTypes.HEADING,
+  text: 'Heading 1',
+  metadata: {
+    tags: [],
+    visibilityOverrides: {},
+  },
+  subItemIds: [],
+  subItems: [],
+};
+
+export const dummyHeadingContentItem2: DenormalizedHeadingContentItem = {
+  id: 'iidk2kfcp2',
+  type: contentItemTypes.HEADING,
+  text: 'Heading 2',
+  metadata: {
+    tags: [],
+    visibilityOverrides: {},
+  },
+  subItemIds: [],
+  subItems: [],
+};
+
+export const dummyHeadingContentItem3: DenormalizedHeadingContentItem = {
+  id: 'vckiiek3ld',
+  type: contentItemTypes.HEADING,
+  text: 'Heading 3',
+  metadata: {
+    tags: [],
+    visibilityOverrides: {},
+  },
+  subItemIds: [],
+  subItems: [],
+};
+
+export const dummyHeadingContentItem4: DenormalizedHeadingContentItem = {
+  id: 'kdivjd3eju',
+  type: contentItemTypes.HEADING,
+  text: 'Heading 4',
+  metadata: {
+    tags: [],
+    visibilityOverrides: {},
+  },
+  subItemIds: [dummySubHeadingContentItem1.id, dummySubHeadingContentItem2.id],
+  subItems: [dummySubHeadingContentItem1, dummySubHeadingContentItem2],
+};
+
+export const dummyHeadingContentItem5: DenormalizedHeadingContentItem = {
+  id: 'dkhjedy2lc',
+  type: contentItemTypes.HEADING,
+  text: 'Heading 5',
+  metadata: {
+    tags: [],
+    visibilityOverrides: {},
+  },
+  subItemIds: [
+    dummyParagraphContentItem1,
+    dummySubHeadingContentItem1.id,
+    dummySubHeadingContentItem2.id,
+  ],
+  subItems: [
+    dummyParagraphContentItem1,
+    dummySubHeadingContentItem1,
+    dummySubHeadingContentItem2,
+  ],
+};
+
+// Root content items
+export const dummyRootContentItem1: DenormalizedRootContentItem = {
+  id: 'ldoivik3dh',
+  type: contentItemTypes.ROOT,
+  childItemIds: [dummyHeadingContentItem1.id, dummyParagraphContentItem1.id],
+  childItems: [
+    dummyHeadingContentItem1,
+    dummyParagraphContentItem1,
+  ],
+};
+
+export const dummyRootContentItem2: DenormalizedRootContentItem = {
+  id: 'ivjdoieo3k',
+  type: contentItemTypes.ROOT,
+  childItemIds: [dummyHeadingContentItem2.id, dummyHeadingContentItem3.id],
+  childItems: [
+    dummyHeadingContentItem2,
+    dummyHeadingContentItem3,
+  ],
+};
+
+export const dummyRootContentItem3: DenormalizedRootContentItem = {
+  id: 'ivjdoieo3k',
+  type: contentItemTypes.ROOT,
+  childItemIds: [dummyHeadingContentItem4.id],
+  childItems: [
+    dummyHeadingContentItem4,
+  ],
+};
+
+export const dummyRootContentItem4: DenormalizedRootContentItem = {
+  id: 'ocodk2fdoi',
+  type: contentItemTypes.ROOT,
+  childItemIds: [dummyHeadingContentItem5.id],
+  childItems: [
+    dummyHeadingContentItem5,
+  ],
+};

--- a/app/lib/content-item-split/index.js
+++ b/app/lib/content-item-split/index.js
@@ -17,7 +17,6 @@ const split = (
 ): Array<DenormalizedContentItem> => {
   switch (contentItem.type) {
     case contentItemTypes.ROOT:
-      console.log(`ROOT: splitting recursively into ${contentItem.childItems.length}`);
       // ROOT content item: split into childItems and recurse
       return contentItem.childItems
         .map((
@@ -32,7 +31,6 @@ const split = (
           return arr.concat(c);
         }, []);
     case contentItemTypes.HEADING: {
-      console.log(`HEADING: splitting into ${contentItem.subItems.length}`);
       /**
        * Algorithm for splitting subheadings, while duplicating the top-level heading
        *
@@ -87,7 +85,6 @@ const split = (
       [createHeading()]);
     }
     default:
-      console.log(`UNKNOWN: not splitting any further`);
       return [contentItem];
   }
 };

--- a/app/lib/content-item-split/index.js
+++ b/app/lib/content-item-split/index.js
@@ -56,8 +56,10 @@ const recursiveSplit = (
         arr: Array<DenormalizedContentItem>,
         item: DenormalizedContentItem,
       ): Array<DenormalizedContentItem> => {
-        if (item.type === contentItemTypes.HEADING) {
+        if (item.type === contentItemTypes.HEADING && arr[arr.length - 1].subItems.length !== 0) {
           // If child is a heading, create and push a new top-level heading
+          // Except if the previous top-level heading has no children (which means that
+          // the current subheading is a direct child of the top-level heading)
           arr.push(createHeading());
         }
 

--- a/app/lib/content-item-split/index.js
+++ b/app/lib/content-item-split/index.js
@@ -2,12 +2,16 @@
 
 import type {
   DenormalizedContentItem,
-  DenormalizedRootContentItem,
 } from 'modules/content-items';
 
 import { contentItemTypes } from 'modules/content-items';
 
-const recursiveSplit = (
+/**
+ * Automatic slide splitting algorithm
+ * @param contentItem: ContentItem
+ * @returns Array<DenormalizedContentItem>
+ */
+const split = (
   contentItem: DenormalizedContentItem,
 ): Array<DenormalizedContentItem> => {
   switch (contentItem.type) {
@@ -18,7 +22,7 @@ const recursiveSplit = (
         .map((
           c: DenormalizedContentItem,
         ): Array<DenormalizedContentItem> => {
-          return recursiveSplit(c);
+          return split(c);
         })
         .reduce((
           arr: Array<DenormalizedContentItem>,
@@ -80,14 +84,6 @@ const recursiveSplit = (
       console.log(`UNKNOWN: not splitting any further`);
       return [contentItem];
   }
-};
-
-/**
- * split - Splits DenormalizedRootContentItem in a list of DenormalizedContentItem
- * Also known as automatic slide splitting algorithm
- */
-const split = (rootContentItem: DenormalizedRootContentItem): Array<DenormalizedContentItem> => {
-  return recursiveSplit(rootContentItem);
 };
 
 export default split;

--- a/app/lib/content-item-split/index.js
+++ b/app/lib/content-item-split/index.js
@@ -3,12 +3,14 @@
 import type {
   DenormalizedContentItem,
   DenormalizedRootContentItem,
+  DenormalizedHeadingContentItem,
 } from 'modules/content-items';
 
 import { contentItemTypes } from 'modules/content-items';
 
 const recursiveSplit = (
   contentItem: DenormalizedContentItem,
+  heading: ?DenormalizedHeadingContentItem,
 ): Array<DenormalizedContentItem> => {
   switch (contentItem.type) {
     case contentItemTypes.ROOT:
@@ -16,13 +18,57 @@ const recursiveSplit = (
       // ROOT content item: split into childItems and recurse
       return contentItem.childItems
         .map((c: DenormalizedContentItem): DenormalizedContentItem => {
-          return recursiveSplit(c);
+          return recursiveSplit(c, heading);
         })
         .reduce((arr, c) => arr.concat(c));
-    case contentItemTypes.HEADING:
-      console.log(`HEADING: adding denormalized content item`);
-      // Add HEADING content item and denormalize
-      return [contentItem];
+    case contentItemTypes.HEADING: {
+      console.log(`HEADING: splitting into ${contentItem.subItems.length}`);
+      /**
+       * Algorithm for splitting subheadings, while duplicating the top-level heading
+       *
+       * Main Heading
+       *    ├─ Paragraph A
+       *    ├─ Subheading 1
+       *    │     └─ Paragraph B
+       *    └─ Subheading 2
+       *          └─ Paragraph C
+       *
+       * To
+       *
+       * Main Heading
+       *    ├─ Paragraph A
+       *    └─ Subheading 1
+       *          └─ Paragraph B
+       * Main Heading
+       *    └─ Subheading 2
+       *          └─ Paragraph C
+       */
+
+      // Return a copy of the top-level heading
+      const createHeading = (): DenormalizedHeadingContentItem => {
+        return {
+          ...contentItem,
+          subItems: [],
+        };
+      };
+
+      const out = contentItem.subItems.reduce((
+        arr: Array<DenormalizedContentItem>,
+        item: DenormalizedContentItem,
+      ): Array<DenormalizedContentItem> => {
+        if (item.type === contentItemTypes.HEADING) {
+          // If child is a heading, create and push a new top-level heading
+          arr.push(createHeading());
+        }
+
+        // Add the child to the last top-level heading
+        arr[arr.length - 1].subItems.push(item);
+        return arr;
+      },
+      [createHeading()]);
+
+      return out;
+    }
     default:
       console.log(`UNKNOWN: not splitting any further`);
       return [contentItem];
@@ -34,7 +80,7 @@ const recursiveSplit = (
  * Also known as automatic slide splitting algorithm
  */
 const split = (rootContentItem: DenormalizedRootContentItem): Array<DenormalizedContentItem> => {
-  return recursiveSplit(rootContentItem);
+  return recursiveSplit(rootContentItem, null);
 };
 
 export default split;

--- a/app/lib/content-item-split/index.js
+++ b/app/lib/content-item-split/index.js
@@ -1,18 +1,40 @@
 // @flow
 
-import contentItems from 'modules/content-items';
-
-const {
-  DenormalizedRootContentItem,
+import type {
   DenormalizedContentItem,
-} = contentItems.model;
+  DenormalizedRootContentItem,
+} from 'modules/content-items';
+
+import { contentItemTypes } from 'modules/content-items';
+
+const recursiveSplit = (
+  contentItem: DenormalizedContentItem,
+): Array<DenormalizedContentItem> => {
+  switch (contentItem.type) {
+    case contentItemTypes.ROOT:
+      console.log(`ROOT: splitting recursively into ${contentItem.childItems.length}`);
+      // ROOT content item: split into childItems and recurse
+      return contentItem.childItems
+        .map((c: DenormalizedContentItem): DenormalizedContentItem => {
+          return recursiveSplit(c);
+        })
+        .reduce((arr, c) => arr.concat(c));
+    case contentItemTypes.HEADING:
+      console.log(`HEADING: adding denormalized content item`);
+      // Add HEADING content item and denormalize
+      return [contentItem];
+    default:
+      console.log(`UNKNOWN: not splitting any further`);
+      return [contentItem];
+  }
+};
 
 /**
  * split - Splits DenormalizedRootContentItem in a list of DenormalizedContentItem
  * Also known as automatic slide splitting algorithm
  */
 const split = (rootContentItem: DenormalizedRootContentItem): Array<DenormalizedContentItem> => {
-  return rootContentItem.childItems;
+  return recursiveSplit(rootContentItem);
 };
 
 export default split;

--- a/app/lib/content-item-split/index.js
+++ b/app/lib/content-item-split/index.js
@@ -1,4 +1,5 @@
 // @flow
+/* eslint-disable flowtype/no-weak-types */
 
 import type {
   DenormalizedContentItem,
@@ -26,7 +27,7 @@ const split = (
         })
         .reduce((
           arr: Array<DenormalizedContentItem>,
-          c: DenormalizedContentItem,
+          c: Array<DenormalizedContentItem>,
         ): Array<DenormalizedContentItem> => {
           return arr.concat(c);
         }, []);
@@ -45,6 +46,9 @@ const split = (
        * To
        *
        * Main Heading
+       *    └─ Paragraph A
+       *
+       * Main Heading
        *    ├─ Paragraph A
        *    └─ Subheading 1
        *          └─ Paragraph B
@@ -54,7 +58,7 @@ const split = (
        */
 
       // Return a copy of the top-level heading
-      const createHeading = (): DenormalizedContentItem => {
+      const createHeading = (): any => {
         return {
           ...contentItem,
           subItemIds: [],
@@ -65,7 +69,7 @@ const split = (
       // Loop over top-level heading's children, splitting and
       // duplicating the top-level heading where necessary.
       return contentItem.subItems.reduce((
-        arr: Array<DenormalizedContentItem>,
+        arr: Array<any>,
         item: DenormalizedContentItem,
       ): Array<DenormalizedContentItem> => {
         if (item.type === contentItemTypes.HEADING && arr[arr.length - 1].subItems.length !== 0) {

--- a/app/lib/content-item-split/index.js
+++ b/app/lib/content-item-split/index.js
@@ -1,0 +1,18 @@
+// @flow
+
+import contentItems from 'modules/content-items';
+
+const {
+  DenormalizedRootContentItem,
+  DenormalizedContentItem,
+} = contentItems.model;
+
+/**
+ * split - Splits DenormalizedRootContentItem in a list of DenormalizedContentItem
+ * Also known as automatic slide splitting algorithm
+ */
+const split = (rootContentItem: DenormalizedRootContentItem): Array<DenormalizedContentItem> => {
+  return [rootContentItem];
+};
+
+export default split;

--- a/app/lib/content-item-split/index.js
+++ b/app/lib/content-item-split/index.js
@@ -3,24 +3,29 @@
 import type {
   DenormalizedContentItem,
   DenormalizedRootContentItem,
-  DenormalizedHeadingContentItem,
 } from 'modules/content-items';
 
 import { contentItemTypes } from 'modules/content-items';
 
 const recursiveSplit = (
   contentItem: DenormalizedContentItem,
-  heading: ?DenormalizedHeadingContentItem,
 ): Array<DenormalizedContentItem> => {
   switch (contentItem.type) {
     case contentItemTypes.ROOT:
       console.log(`ROOT: splitting recursively into ${contentItem.childItems.length}`);
       // ROOT content item: split into childItems and recurse
       return contentItem.childItems
-        .map((c: DenormalizedContentItem): DenormalizedContentItem => {
-          return recursiveSplit(c, heading);
+        .map((
+          c: DenormalizedContentItem,
+        ): Array<DenormalizedContentItem> => {
+          return recursiveSplit(c);
         })
-        .reduce((arr, c) => arr.concat(c));
+        .reduce((
+          arr: Array<DenormalizedContentItem>,
+          c: DenormalizedContentItem,
+        ): Array<DenormalizedContentItem> => {
+          return arr.concat(c);
+        }, []);
     case contentItemTypes.HEADING: {
       console.log(`HEADING: splitting into ${contentItem.subItems.length}`);
       /**
@@ -45,14 +50,16 @@ const recursiveSplit = (
        */
 
       // Return a copy of the top-level heading
-      const createHeading = (): DenormalizedHeadingContentItem => {
+      const createHeading = (): DenormalizedContentItem => {
         return {
           ...contentItem,
           subItems: [],
         };
       };
 
-      const out = contentItem.subItems.reduce((
+      // Loop over top-level heading's children, splitting and
+      // duplicating the top-level heading where necessary.
+      return contentItem.subItems.reduce((
         arr: Array<DenormalizedContentItem>,
         item: DenormalizedContentItem,
       ): Array<DenormalizedContentItem> => {
@@ -68,8 +75,6 @@ const recursiveSplit = (
         return arr;
       },
       [createHeading()]);
-
-      return out;
     }
     default:
       console.log(`UNKNOWN: not splitting any further`);
@@ -82,7 +87,7 @@ const recursiveSplit = (
  * Also known as automatic slide splitting algorithm
  */
 const split = (rootContentItem: DenormalizedRootContentItem): Array<DenormalizedContentItem> => {
-  return recursiveSplit(rootContentItem, null);
+  return recursiveSplit(rootContentItem);
 };
 
 export default split;

--- a/app/lib/content-item-split/index.js
+++ b/app/lib/content-item-split/index.js
@@ -57,6 +57,7 @@ const split = (
       const createHeading = (): DenormalizedContentItem => {
         return {
           ...contentItem,
+          subItemIds: [],
           subItems: [],
         };
       };
@@ -75,6 +76,7 @@ const split = (
         }
 
         // Add the child to the last top-level heading
+        arr[arr.length - 1].subItemIds.push(item.id);
         arr[arr.length - 1].subItems.push(item);
         return arr;
       },

--- a/app/lib/content-item-split/index.js
+++ b/app/lib/content-item-split/index.js
@@ -12,7 +12,7 @@ const {
  * Also known as automatic slide splitting algorithm
  */
 const split = (rootContentItem: DenormalizedRootContentItem): Array<DenormalizedContentItem> => {
-  return [rootContentItem];
+  return rootContentItem.childItems;
 };
 
 export default split;

--- a/app/lib/content-item-split/tests/index.test.js
+++ b/app/lib/content-item-split/tests/index.test.js
@@ -1,0 +1,59 @@
+// @flow
+
+import * as data from '../dummyData';
+
+import split from '..';
+
+describe(`split`, (): void => {
+
+  it(`splits rootContentItem into childItems`, (): void => {
+    const result = split(data.dummyRootContentItem1);
+
+    expect(result).toEqual([data.dummyHeadingContentItem1, data.dummyParagraphContentItem1]);
+  });
+
+  it(`splits every top-level heading into a new slide`, (): void => {
+    const result = split(data.dummyRootContentItem2);
+
+    expect(result).toEqual([data.dummyHeadingContentItem2, data.dummyHeadingContentItem3]);
+  });
+
+  it(`splits top-level heading with two subheadings into two slides with duplicated top-level headings`, (): void => {
+    const result = split(data.dummyRootContentItem3);
+
+    expect(result).toEqual([
+      {
+        ...data.dummyHeadingContentItem4,
+        subItemIds: [data.dummySubHeadingContentItem1.id],
+        subItems: [data.dummySubHeadingContentItem1],
+      },
+      {
+        ...data.dummyHeadingContentItem4,
+        subItemIds: [data.dummySubHeadingContentItem2.id],
+        subItems: [data.dummySubHeadingContentItem2],
+      },
+    ]);
+  });
+
+  it(`splits top-level heading with paragraph and two subheadings into three slides with duplicated top-level headings`, (): void => {
+    const result = split(data.dummyRootContentItem4);
+
+    expect(result).toEqual([
+      {
+        ...data.dummyHeadingContentItem5,
+        subItemIds: [data.dummyParagraphContentItem1.id],
+        subItems: [data.dummyParagraphContentItem1],
+      },
+      {
+        ...data.dummyHeadingContentItem5,
+        subItemIds: [data.dummySubHeadingContentItem1.id],
+        subItems: [data.dummySubHeadingContentItem1],
+      },
+      {
+        ...data.dummyHeadingContentItem5,
+        subItemIds: [data.dummySubHeadingContentItem2.id],
+        subItems: [data.dummySubHeadingContentItem2],
+      },
+    ]);
+  });
+});

--- a/app/modules/content-items/dummyData.js
+++ b/app/modules/content-items/dummyData.js
@@ -175,7 +175,7 @@ export const dummyContentItemsById: ContentItemsById = {
       tags: [],
       visibilityOverrides: {},
     },
-    subItemIds: ['vl4jfkdj4l', 'kdo4lbvn5l', 'lhjdki4hvi', 'dk3j5cl34k'],
+    subItemIds: ['vl4jfkdj4l', 'kdo4lbvn5l', 'lhjdki4hvi', 'dk3j5cl34k', 'dlidlf3ejk'],
   },
   kdo4lbvn5l: {
     id: 'kdo4lbvn5l',
@@ -237,6 +237,16 @@ export const dummyContentItemsById: ContentItemsById = {
     },
     subItemIds: [],
   }: ParagraphContentItem),
+  dlidlf3ejk: {
+    id: 'dlidlf3ejk',
+    type: contentItemTypes.HEADING,
+    text: 'Subheading 3',
+    metadata: {
+      tags: [],
+      visibilityOverrides: {},
+    },
+    subItemIds: [],
+  },
   kchwki48cd: {
     id: 'kchwki48cd',
     type: contentItemTypes.HEADING,
@@ -245,8 +255,28 @@ export const dummyContentItemsById: ContentItemsById = {
       tags: [],
       visibilityOverrides: {},
     },
-    subItemIds: [],
+    subItemIds: ['kweoi4kivf'],
   },
+  kweoi4kivf: {
+    id: 'kweoi4kivf',
+    type: contentItemTypes.HEADING,
+    text: 'Yep, super boring here',
+    metadata: {
+      tags: [],
+      visibilityOverrides: {},
+    },
+    subItemIds: ['focej3icjd'],
+  },
+  focej3icjd: ({
+    id: 'focej3icjd',
+    type: contentItemTypes.PARAGRAPH,
+    text: 'Lorem **ipsum** dolor `sit` amet, [consectetur](https://www.lipsum.com) adipiscing *elit*. Mauris *accumsan* pretium sem, in volutpat nibh sodales a. **Nulla blandit** posuere ex, et [facilisis](https://www.lipsum.com) dui volutpat in.',
+    metadata: {
+      tags: [],
+      visibilityOverrides: {},
+    },
+    subItemIds: [],
+  }: ParagraphContentItem),
   ck2k4kvcj4: {
     id: 'ck2k4kvcj4',
     type: contentItemTypes.HEADING,

--- a/app/modules/content-items/dummyData.js
+++ b/app/modules/content-items/dummyData.js
@@ -45,7 +45,7 @@ export const dummyContentItemsById: ContentItemsById = {
   qyrgv0bcd6: {
     id: 'qyrgv0bcd6',
     type: contentItemTypes.ROOT,
-    childItemIds: ['j0vcu0y7vk', 'ua32xchh7q'],
+    childItemIds: ['ivks4jgtxr', 'j0vcu0y7vk', 'ua32xchh7q', 'kcosdhj38v', 'kchwki48cd', 'ck2k4kvcj4', 'ldicl3j4jk'],
   },
   j0vcu0y7vk: {
     id: 'j0vcu0y7vk',
@@ -137,4 +137,74 @@ export const dummyContentItemsById: ContentItemsById = {
     },
     subItemIds: [],
   }: ParagraphContentItem),
+  ivks4jgtxr: {
+    id: 'ivks4jgtxr',
+    type: contentItemTypes.HEADING,
+    text: 'This is a heading',
+    metadata: {
+      tags: [],
+      visibilityOverrides: {},
+    },
+    subItemIds: ['oswmjc09be', 'jbv2ju5jc6'],
+  },
+  oswmjc09be: ({
+    id: 'oswmjc09be',
+    type: contentItemTypes.PARAGRAPH,
+    text: 'Lorem **ipsum** dolor `sit` amet, [consectetur](https://www.lipsum.com) adipiscing *elit*.',
+    metadata: {
+      tags: [],
+      visibilityOverrides: {},
+    },
+    subItemIds: [],
+  }: ParagraphContentItem),
+  jbv2ju5jc6: ({
+    id: 'jbv2ju5jc6',
+    type: contentItemTypes.PARAGRAPH,
+    text: 'Mauris accumsan pretium sem, in volutpat nibh sodales a. Nulla blandit posuere ex, et facilisis dui volutpat in. Fusce tincidunt sed ipsum quis varius. Quisque vitae laoreet sem.',
+    metadata: {
+      tags: [],
+      visibilityOverrides: {},
+    },
+    subItemIds: [],
+  }: ParagraphContentItem),
+  kcosdhj38v: {
+    id: 'kcosdhj38v',
+    type: contentItemTypes.HEADING,
+    text: 'Open Webslides slide rendering',
+    metadata: {
+      tags: [],
+      visibilityOverrides: {},
+    },
+    subItemIds: [],
+  },
+  kchwki48cd: {
+    id: 'kchwki48cd',
+    type: contentItemTypes.HEADING,
+    text: 'Yet Another Heading That Is Boring',
+    metadata: {
+      tags: [],
+      visibilityOverrides: {},
+    },
+    subItemIds: [],
+  },
+  ck2k4kvcj4: {
+    id: 'ck2k4kvcj4',
+    type: contentItemTypes.HEADING,
+    text: '10 Reasons Why You Should Read This',
+    metadata: {
+      tags: [],
+      visibilityOverrides: {},
+    },
+    subItemIds: [],
+  },
+  ldicl3j4jk: {
+    id: 'ldicl3j4jk',
+    type: contentItemTypes.HEADING,
+    text: 'Welcome to the presentation',
+    metadata: {
+      tags: [],
+      visibilityOverrides: {},
+    },
+    subItemIds: [],
+  },
 };

--- a/app/modules/content-items/dummyData.js
+++ b/app/modules/content-items/dummyData.js
@@ -175,8 +175,48 @@ export const dummyContentItemsById: ContentItemsById = {
       tags: [],
       visibilityOverrides: {},
     },
-    subItemIds: [],
+    subItemIds: ['kdo4lbvn5l', 'lhjdki4hvi'],
   },
+  kdo4lbvn5l: {
+    id: 'kdo4lbvn5l',
+    type: contentItemTypes.HEADING,
+    text: 'Subheading 1',
+    metadata: {
+      tags: [],
+      visibilityOverrides: {},
+    },
+    subItemIds: ['kdl3l4jkvd'],
+  },
+  kdl3l4jkvd: ({
+    id: 'kdl3l4jkvd',
+    type: contentItemTypes.PARAGRAPH,
+    text: 'Lorem **ipsum** dolor `sit` amet, [consectetur](https://www.lipsum.com) adipiscing *elit*. Mauris *accumsan* pretium sem, in volutpat nibh sodales a. **Nulla blandit** posuere ex, et [facilisis](https://www.lipsum.com) dui volutpat in.',
+    metadata: {
+      tags: [],
+      visibilityOverrides: {},
+    },
+    subItemIds: [],
+  }: ParagraphContentItem),
+  lhjdki4hvi: {
+    id: 'lhjdki4hvi',
+    type: contentItemTypes.HEADING,
+    text: 'Subheading 2',
+    metadata: {
+      tags: [],
+      visibilityOverrides: {},
+    },
+    subItemIds: ['kdloeijdj3'],
+  },
+  kdloeijdj3: ({
+    id: 'kdl3l4jkvd',
+    type: contentItemTypes.PARAGRAPH,
+    text: 'Lorem **ipsum** dolor `sit` amet, [consectetur](https://www.lipsum.com) adipiscing *elit*. Mauris *accumsan* pretium sem, in volutpat nibh sodales a. **Nulla blandit** posuere ex, et [facilisis](https://www.lipsum.com) dui volutpat in.',
+    metadata: {
+      tags: [],
+      visibilityOverrides: {},
+    },
+    subItemIds: [],
+  }: ParagraphContentItem),
   kchwki48cd: {
     id: 'kchwki48cd',
     type: contentItemTypes.HEADING,

--- a/app/modules/content-items/dummyData.js
+++ b/app/modules/content-items/dummyData.js
@@ -175,7 +175,7 @@ export const dummyContentItemsById: ContentItemsById = {
       tags: [],
       visibilityOverrides: {},
     },
-    subItemIds: ['kdo4lbvn5l', 'lhjdki4hvi'],
+    subItemIds: ['vl4jfkdj4l', 'kdo4lbvn5l', 'lhjdki4hvi', 'dk3j5cl34k'],
   },
   kdo4lbvn5l: {
     id: 'kdo4lbvn5l',
@@ -197,6 +197,16 @@ export const dummyContentItemsById: ContentItemsById = {
     },
     subItemIds: [],
   }: ParagraphContentItem),
+  vl4jfkdj4l: ({
+    id: 'vl4jfkdj4l',
+    type: contentItemTypes.PARAGRAPH,
+    text: 'Introduction to the *Open Webslides **Slide Rendering** for noobs*',
+    metadata: {
+      tags: [],
+      visibilityOverrides: {},
+    },
+    subItemIds: [],
+  }: ParagraphContentItem),
   lhjdki4hvi: {
     id: 'lhjdki4hvi',
     type: contentItemTypes.HEADING,
@@ -207,8 +217,18 @@ export const dummyContentItemsById: ContentItemsById = {
     },
     subItemIds: ['kdloeijdj3'],
   },
+  dk3j5cl34k: ({
+    id: 'dk3j5cl34k',
+    type: contentItemTypes.PARAGRAPH,
+    text: 'Lorem **ipsum** dolor `sit` amet, [consectetur](https://www.lipsum.com) adipiscing *elit*.',
+    metadata: {
+      tags: [],
+      visibilityOverrides: {},
+    },
+    subItemIds: [],
+  }: ParagraphContentItem),
   kdloeijdj3: ({
-    id: 'kdl3l4jkvd',
+    id: 'kdloeijdj3',
     type: contentItemTypes.PARAGRAPH,
     text: 'Lorem **ipsum** dolor `sit` amet, [consectetur](https://www.lipsum.com) adipiscing *elit*. Mauris *accumsan* pretium sem, in volutpat nibh sodales a. **Nulla blandit** posuere ex, et [facilisis](https://www.lipsum.com) dui volutpat in.',
     metadata: {

--- a/app/pages/components/TempSlideTestPage.js
+++ b/app/pages/components/TempSlideTestPage.js
@@ -8,7 +8,7 @@ import type { CustomTranslatorProps } from 'types/translator';
 import type { State } from 'types/state';
 import contentItems, { contentItemTypes } from 'modules/content-items';
 import type { DenormalizedRootContentItem } from 'modules/content-items';
-import Slide from 'core-components/slides/Slide';
+import Slides from 'core-components/slides/Slides';
 
 import Page from '../Page';
 
@@ -48,7 +48,7 @@ const PureTempSlideTestPage = (props: Props): React.Node => {
 
   return (
     <Page>
-      <Slide contentItemTreeRootItem={contentItemTreeRootItem} />
+      <Slides contentItemTreeRootItem={contentItemTreeRootItem} />
     </Page>
   );
 };


### PR DESCRIPTION
- Add `<Slides>`: multiple slides overview
- Basic slide splitting
  - New slide for every top-level heading
  - New slide for every subheading + duplicated top-level heading

I could not get Flow to cooperate on the `lib/content-item-split/index` file. Anyone any suggestions?