### PR TITLE
Fix babel / webpack config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,10 +8,9 @@
     "flow-react-proptypes",
     "react-hot-loader/babel",
     ["transform-builtin-extend", {
-     "globals": ["Error"]
+      "globals": ["Error"]
     }],
     "transform-class-properties",
-    "transform-object-rest-spread",
-    "transform-runtime"
+    "transform-object-rest-spread"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-flow": "^6.23.0",
     "babel-preset-react": "^6.24.1",
@@ -54,6 +53,7 @@
     "webpack-merge": "^4.1.2"
   },
   "dependencies": {
+    "babel-polyfill": "^6.26.0",
     "blueimp-md5": "^2.10.0",
     "i18next": "^11.3.2",
     "lodash": "^4.17.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,7 @@ const paths = {
 // Webpack base configuration
 const baseConfig = {
 
-  entry: path.join(paths.APP, 'index.js'),
+  entry: ['babel-polyfill', path.join(paths.APP, 'index.js')],
 
   output: {
     filename: 'app.bundle.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1083,12 +1083,6 @@ babel-plugin-transform-regenerator@^6.22.0:
   dependencies:
     regenerator-transform "^0.10.0"
 
-babel-plugin-transform-runtime@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
-  dependencies:
-    babel-runtime "^6.22.0"
-
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"


### PR DESCRIPTION
Removed `babel-plugin-transform-runtime` and replaced it with `babel-polyfill`, because a) the polyfill is recommended for apps, and b) transform-runtime was causing errors when using `export * from './file'` syntax.