### PR TITLE
Eslint-promise

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   'extends': [
     'airbnb',
     'plugin:flowtype/recommended',
+    'plugin:promise/recommended',
   ],
   'env': {
     // Don't throw error when using global browser variables such as 'document' or 'window'.
@@ -14,6 +15,8 @@ module.exports = {
     'flowtype',
     // ESLint checking for Jest tests.
     'jest',
+    // ESLint checking for correct use of Promise / async features.
+    'promise',
   ],
   'settings': {
     // Temporary workaround for https://github.com/benmosher/eslint-plugin-import/issues/793 #TODO
@@ -257,6 +260,10 @@ module.exports = {
         'newlines-between': 'always',
       },
     ],
+
+    // Enforce using ES2017 async/await syntax for asynchronous functionality.
+    'promise/prefer-await-to-then': 'error',
+    'promise/prefer-await-to-callbacks': 'error',
 
     // Doesn't play wel with semantic-ui-react; #TODO look for a way to fix this; perhaps write wrapper for label?
     'jsx-a11y/label-has-for': 'off',

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eslint-plugin-import": "^2.13.0",
     "eslint-plugin-jest": "^21.17.0",
     "eslint-plugin-jsx-a11y": "^6.1.0",
+    "eslint-plugin-promise": "^3.8.0",
     "eslint-plugin-react": "^7.10.0",
     "file-loader": "^1.1.11",
     "flow-bin": "^0.76.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2827,6 +2827,10 @@ eslint-plugin-jsx-a11y@^6.1.0:
     has "^1.0.3"
     jsx-ast-utils "^2.0.1"
 
+eslint-plugin-promise@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.8.0.tgz#65ebf27a845e3c1e9d6f6a5622ddd3801694b621"
+
 eslint-plugin-react@^7.10.0:
   version "7.10.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.10.0.tgz#af5c1fef31c4704db02098f9be18202993828b50"


### PR DESCRIPTION
 Installed eslint-plugin-promise and configured it to enforce using async/await syntax for asynchronous functionality. See https://trello.com/c/T52TGjv8