### PR TITLE
Feature dummy providers

### DIFF
--- a/app/components/ApplicationPage/AuthPage/ConfirmEmailPage/index.test.js
+++ b/app/components/ApplicationPage/AuthPage/ConfirmEmailPage/index.test.js
@@ -2,13 +2,8 @@
 
 import * as React from 'react';
 import { shallow, mount } from 'enzyme';
-import { createStore } from 'redux';
-import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
-import { I18nextProvider } from 'react-i18next';
 
-import i18nextConfig from 'config/i18next';
-import { dummyProviderProps } from 'lib/testResources';
+import { DummyProviders, dummyProviderProps } from 'lib/testResources';
 import { InvalidArgumentError } from 'errors';
 import platform from 'modules/platform';
 
@@ -20,24 +15,19 @@ describe(`ConfirmEmailPage`, (): void => {
   let dummyConfirmEmail: *;
 
   let dummyDispatch: *;
-  let dummyReducer: *;
   let dummyState: any;
-  let dummyStore: *;
 
   beforeEach((): void => {
     dummyConfirmationToken = 'foobarToken';
     dummyConfirmEmail = jest.fn();
 
     dummyDispatch = jest.fn();
-    dummyReducer = (state: any = {}, action: any): any => state;
     dummyState = {
       modules: {
         apiRequestsStatus: {},
         platform: { userAuth: null },
       },
     };
-    dummyStore = createStore(dummyReducer, dummyState);
-    dummyStore.dispatch = dummyDispatch;
   });
 
   it(`renders without errors`, (): void => {
@@ -76,13 +66,9 @@ describe(`ConfirmEmailPage`, (): void => {
 
     // eslint-disable-next-line no-unused-vars
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <I18nextProvider i18n={i18nextConfig}>
-          <MemoryRouter>
-            <ConfirmEmailPage {...fixedDummyRouterProps} />
-          </MemoryRouter>
-        </I18nextProvider>
-      </Provider>,
+      <DummyProviders dummyState={dummyState} dummyDispatch={dummyDispatch}>
+        <ConfirmEmailPage {...fixedDummyRouterProps} />
+      </DummyProviders>,
     );
 
     expect(dummyDispatch).toHaveBeenCalledWith(platform.actions.confirmEmail(dummyConfirmationToken));

--- a/app/components/ApplicationPage/UserPage/SignoutPage/index.test.js
+++ b/app/components/ApplicationPage/UserPage/SignoutPage/index.test.js
@@ -2,12 +2,8 @@
 
 import * as React from 'react';
 import { mount } from 'enzyme';
-import { createStore } from 'redux';
-import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
-import { I18nextProvider } from 'react-i18next';
 
-import i18nextConfig from 'config/i18next';
+import { DummyProviders } from 'lib/testResources';
 import platform from 'modules/platform';
 
 import SignoutPage from '.';
@@ -15,25 +11,16 @@ import SignoutPage from '.';
 describe(`SignoutPage`, (): void => {
 
   let dummyDispatch: *;
-  let dummyReducer: *;
-  let dummyStore: *;
 
   beforeEach((): void => {
     dummyDispatch = jest.fn();
-    dummyReducer = (state: any = {}, action: any): any => state;
-    dummyStore = createStore(dummyReducer, {});
-    dummyStore.dispatch = dummyDispatch;
   });
 
   it(`dispatches a signout action on load`, (): void => {
     mount(
-      <Provider store={dummyStore}>
-        <I18nextProvider i18n={i18nextConfig}>
-          <MemoryRouter>
-            <SignoutPage />
-          </MemoryRouter>
-        </I18nextProvider>
-      </Provider>,
+      <DummyProviders dummyDispatch={dummyDispatch}>
+        <SignoutPage />
+      </DummyProviders>,
     );
 
     expect(dummyDispatch).toHaveBeenCalledWith(platform.actions.signout());

--- a/app/components/ConditionalWrapper/index.test.js
+++ b/app/components/ConditionalWrapper/index.test.js
@@ -1,24 +1,14 @@
 // @flow
 
 import * as React from 'react';
-import { createStore } from 'redux';
-import { Provider } from 'react-redux';
-import { MemoryRouter, Route, Switch } from 'react-router-dom';
 import { shallow, mount } from 'enzyme';
+import { Switch, Route } from 'react-router-dom';
 
-import { dummyProviderProps } from 'lib/testResources';
+import { DummyProviders, dummyProviderProps } from 'lib/testResources';
 
 import ConditionalWrapper, { PureConditionalWrapper } from '.';
 
 describe(`ConditionalWrapper`, (): void => {
-
-  let dummyReducer: *;
-  let dummyStore: *;
-
-  beforeEach((): void => {
-    dummyReducer = (state: any = {}, action: any): any => state;
-    dummyStore = createStore(dummyReducer, {});
-  });
 
   it(`renders without errors`, (): void => {
     const enzymeWrapper = shallow(
@@ -31,14 +21,12 @@ describe(`ConditionalWrapper`, (): void => {
 
   it(`renders its children, when renderChildren is TRUE`, (): void => {
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <MemoryRouter initialEntries={['/test']}>
-          <ConditionalWrapper renderChildren={true}>
-            <p>Secure text</p>
-            <p>More secure text</p>
-          </ConditionalWrapper>
-        </MemoryRouter>
-      </Provider>,
+      <DummyProviders>
+        <ConditionalWrapper renderChildren={true}>
+          <p>Secure text</p>
+          <p>More secure text</p>
+        </ConditionalWrapper>
+      </DummyProviders>,
     );
     const conditionalWrapperChildren = enzymeWrapper.find('PureConditionalWrapper').children();
 
@@ -49,14 +37,12 @@ describe(`ConditionalWrapper`, (): void => {
 
   it(`does not render its children, when renderChildren is FALSE`, (): void => {
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <MemoryRouter initialEntries={['/test']}>
-          <ConditionalWrapper renderChildren={false}>
-            <p>Secure text</p>
-            <p>More secure text</p>
-          </ConditionalWrapper>
-        </MemoryRouter>
-      </Provider>,
+      <DummyProviders>
+        <ConditionalWrapper renderChildren={false}>
+          <p>Secure text</p>
+          <p>More secure text</p>
+        </ConditionalWrapper>
+      </DummyProviders>,
     );
     const conditionalWrapperChildren = enzymeWrapper.find('PureConditionalWrapper').children();
 
@@ -67,14 +53,12 @@ describe(`ConditionalWrapper`, (): void => {
     const DummyConditionalComponent = (): React.Node => <p>Access denied</p>;
 
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <MemoryRouter initialEntries={['/test']}>
-          <ConditionalWrapper renderChildren={false} componentIfNotChildren={DummyConditionalComponent}>
-            <p>Secure text</p>
-            <p>More secure text</p>
-          </ConditionalWrapper>
-        </MemoryRouter>
-      </Provider>,
+      <DummyProviders dummyRouterEntries={['/test']}>
+        <ConditionalWrapper renderChildren={false} componentIfNotChildren={DummyConditionalComponent}>
+          <p>Secure text</p>
+          <p>More secure text</p>
+        </ConditionalWrapper>
+      </DummyProviders>,
     );
     const conditionalWrapperChildren = enzymeWrapper.find('PureConditionalWrapper').children();
 
@@ -91,14 +75,12 @@ describe(`ConditionalWrapper`, (): void => {
     );
 
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <MemoryRouter initialEntries={['/test']}>
-          <Switch>
-            <Route path="/test" exact={true} component={ConditionalWrapperComponent} />
-            <Route path="/dummyUrl" component={(): React.Node => (<p>Access denied</p>)} />
-          </Switch>
-        </MemoryRouter>
-      </Provider>,
+      <DummyProviders dummyRouterEntries={['/test']}>
+        <Switch>
+          <Route path="/test" exact={true} component={ConditionalWrapperComponent} />
+          <Route path="/dummyUrl" component={(): React.Node => (<p>Access denied</p>)} />
+        </Switch>
+      </DummyProviders>,
     );
 
     expect(enzymeWrapper.text()).toContain('Access denied');

--- a/app/components/FlashMessages/index.test.js
+++ b/app/components/FlashMessages/index.test.js
@@ -2,13 +2,8 @@
 
 import * as React from 'react';
 import { shallow, mount } from 'enzyme';
-import { createStore } from 'redux';
-import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
-import { I18nextProvider } from 'react-i18next';
 
-import i18nextConfig from 'config/i18next';
-import { dummyProviderProps } from 'lib/testResources';
+import { DummyProviders, dummyProviderProps } from 'lib/testResources';
 
 import FlashMessages, { PureFlashMessages } from '.';
 
@@ -18,8 +13,6 @@ describe(`FlashMessages`, (): void => {
 
   let dummyState: any;
   let dummyDispatch: *;
-  let dummyReducer: *;
-  let dummyStore: *;
 
   beforeEach((): void => {
     dummyLatestFlashMessage = {
@@ -42,9 +35,6 @@ describe(`FlashMessages`, (): void => {
       },
     };
     dummyDispatch = jest.fn();
-    dummyReducer = (state: any = {}, action: any): any => state;
-    dummyStore = createStore(dummyReducer, dummyState);
-    dummyStore.dispatch = dummyDispatch;
   });
 
   it(`renders without errors`, (): void => {
@@ -78,13 +68,9 @@ describe(`FlashMessages`, (): void => {
 
   it(`renders the latest flash message`, (): void => {
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <I18nextProvider i18n={i18nextConfig}>
-          <MemoryRouter>
-            <FlashMessages />
-          </MemoryRouter>
-        </I18nextProvider>
-      </Provider>,
+      <DummyProviders dummyState={dummyState} dummyDispatch={dummyDispatch}>
+        <FlashMessages />
+      </DummyProviders>,
     );
 
     expect(enzymeWrapper.text()).toContain('test.string.present');

--- a/app/components/PageWrapper/NavigationBar/AccountMenu/index.test.js
+++ b/app/components/PageWrapper/NavigationBar/AccountMenu/index.test.js
@@ -2,13 +2,8 @@
 
 import * as React from 'react';
 import { shallow, mount } from 'enzyme';
-import { createStore } from 'redux';
-import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
-import { I18nextProvider } from 'react-i18next';
 
-import i18nextConfig from 'config/i18next';
-import { dummyUserData } from 'lib/testResources';
+import { DummyProviders, dummyUserData } from 'lib/testResources';
 import users from 'modules/users';
 
 import AccountMenu, { PureAccountMenu } from '.';
@@ -16,10 +11,7 @@ import AccountMenu, { PureAccountMenu } from '.';
 describe(`AccountMenu`, (): void => {
 
   let dummyUser: users.model.User;
-
   let dummyState: any;
-  let dummyReducer: *;
-  let dummyStore: *;
 
   beforeEach((): void => {
     dummyUser = { ...dummyUserData.user };
@@ -35,8 +27,6 @@ describe(`AccountMenu`, (): void => {
         },
       },
     };
-    dummyReducer = (state: any = {}, action: any): any => state;
-    dummyStore = createStore(dummyReducer, dummyState);
   });
 
   it(`renders without errors`, (): void => {
@@ -48,13 +38,9 @@ describe(`AccountMenu`, (): void => {
 
   it(`renders UserAccountMenu, when there is a current user`, (): void => {
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <I18nextProvider i18n={i18nextConfig}>
-          <MemoryRouter>
-            <AccountMenu />
-          </MemoryRouter>
-        </I18nextProvider>
-      </Provider>,
+      <DummyProviders dummyState={dummyState}>
+        <AccountMenu />
+      </DummyProviders>,
     );
 
     expect(enzymeWrapper.find('PureUserAccountMenu')).toHaveLength(1);
@@ -65,13 +51,9 @@ describe(`AccountMenu`, (): void => {
     dummyState.modules.platform.userAuth = null;
 
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <I18nextProvider i18n={i18nextConfig}>
-          <MemoryRouter>
-            <AccountMenu />
-          </MemoryRouter>
-        </I18nextProvider>
-      </Provider>,
+      <DummyProviders dummyState={dummyState}>
+        <AccountMenu />
+      </DummyProviders>,
     );
 
     expect(enzymeWrapper.find('PureUserAccountMenu')).toHaveLength(0);

--- a/app/components/SidebarsPageWrapper/index.test.js
+++ b/app/components/SidebarsPageWrapper/index.test.js
@@ -2,13 +2,8 @@
 
 import * as React from 'react';
 import { shallow, mount } from 'enzyme';
-import { createStore } from 'redux';
-import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
-import { I18nextProvider } from 'react-i18next';
 
-import i18nextConfig from 'config/i18next';
-import { dummyTopicData, dummyContentItemData } from 'lib/testResources';
+import { DummyProviders, dummyTopicData, dummyContentItemData } from 'lib/testResources';
 import platform from 'modules/platform';
 import topics from 'modules/topics';
 
@@ -20,8 +15,6 @@ describe(`SidebarsPageWrapper`, (): void => {
   let dummyState: any;
 
   let dummyDispatch: *;
-  let dummyReducer: *;
-  let dummyStore: *;
 
   beforeEach((): void => {
     dummyTopic = { ...dummyTopicData.topic, rootContentItemId: dummyContentItemData.rootContentItem.id };
@@ -47,11 +40,7 @@ describe(`SidebarsPageWrapper`, (): void => {
         messages: [],
       },
     };
-
     dummyDispatch = jest.fn();
-    dummyReducer = (state: any = {}, action: any): any => state;
-    dummyStore = createStore(dummyReducer, dummyState);
-    dummyStore.dispatch = dummyDispatch;
   });
 
   it(`renders without errors`, (): void => {
@@ -66,15 +55,11 @@ describe(`SidebarsPageWrapper`, (): void => {
 
   it(`gets the correct activeSidebarsCount`, (): void => {
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <I18nextProvider i18n={i18nextConfig}>
-          <MemoryRouter>
-            <SidebarsPageWrapper topicId={dummyTopic.id}>
-              <p>Page content</p>
-            </SidebarsPageWrapper>
-          </MemoryRouter>
-        </I18nextProvider>
-      </Provider>,
+      <DummyProviders dummyState={dummyState} dummyDispatch={dummyDispatch}>
+        <SidebarsPageWrapper topicId={dummyTopic.id}>
+          <p>Page content</p>
+        </SidebarsPageWrapper>
+      </DummyProviders>,
     );
 
     expect(enzymeWrapper.find('PureSidebarsPageWrapper').props().activeSidebarsCount).toBe(2);

--- a/app/forms/UserForm/index.test.js
+++ b/app/forms/UserForm/index.test.js
@@ -2,25 +2,12 @@
 
 import * as React from 'react';
 import { shallow, mount } from 'enzyme';
-import { createStore } from 'redux';
-import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
-import { I18nextProvider } from 'react-i18next';
 
-import i18nextConfig from 'config/i18next';
-import { dummyProviderProps } from 'lib/testResources';
+import { DummyProviders, dummyProviderProps } from 'lib/testResources';
 
 import UserForm, { PureUserForm } from '.';
 
 describe(`UserForm`, (): void => {
-
-  let dummyReducer: *;
-  let dummyStore: *;
-
-  beforeEach((): void => {
-    dummyReducer = (state: any = {}, action: any): any => state;
-    dummyStore = createStore(dummyReducer, {});
-  });
 
   it(`renders without errors`, (): void => {
     const enzymeWrapper = shallow(
@@ -31,13 +18,9 @@ describe(`UserForm`, (): void => {
 
   it(`checks its checkbox #TEMP`, (): void => {
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <I18nextProvider i18n={i18nextConfig}>
-          <MemoryRouter>
-            <UserForm />
-          </MemoryRouter>
-        </I18nextProvider>
-      </Provider>,
+      <DummyProviders>
+        <UserForm />
+      </DummyProviders>,
     );
 
     const checkboxNode = enzymeWrapper.find('[data-test-id="user-form-tos-accepted"]').hostNodes();

--- a/app/lib/testResources/DummyProviders.js
+++ b/app/lib/testResources/DummyProviders.js
@@ -1,0 +1,50 @@
+// @flow
+/* eslint-disable flowtype/no-weak-types */
+
+import * as React from 'react';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
+import { MemoryRouter, type LocationShape } from 'react-router-dom';
+import { I18nextProvider } from 'react-i18next';
+
+import i18nextConfig from 'config/i18next';
+
+type PassedProps = {|
+  children: React.Node,
+  dummyState?: Object,
+  dummyDispatch?: Dispatch<*>,
+  dummyRouterEntries?: Array<LocationShape | string>,
+|};
+
+type Props = {| ...PassedProps |};
+
+const DummyProviders = (props: Props): React.Node => {
+  const {
+    children,
+    dummyState,
+    dummyDispatch,
+    dummyRouterEntries,
+  } = props;
+
+  const dummyReducer = (state: any = {}, action: any): any => state;
+  const dummyStore = createStore(dummyReducer, dummyState);
+  dummyStore.dispatch = dummyDispatch;
+
+  return (
+    <Provider store={dummyStore}>
+      <I18nextProvider i18n={i18nextConfig}>
+        <MemoryRouter initialEntries={dummyRouterEntries}>
+          {children}
+        </MemoryRouter>
+      </I18nextProvider>
+    </Provider>
+  );
+};
+
+DummyProviders.defaultProps = {
+  dummyState: {},
+  dummyDispatch: jest.fn(),
+  dummyRouterEntries: [''],
+};
+
+export default DummyProviders;

--- a/app/lib/testResources/index.js
+++ b/app/lib/testResources/index.js
@@ -4,10 +4,12 @@ import * as dummyContentItemData from './dummyContentItemData';
 import * as dummyTopicData from './dummyTopicData';
 import * as dummyUserData from './dummyUserData';
 import * as dummyProviderProps from './dummyProviderProps';
+import DummyProviders from './DummyProviders';
 
 export {
   dummyContentItemData,
   dummyTopicData,
   dummyUserData,
   dummyProviderProps,
+  DummyProviders,
 };

--- a/app/modules/apiRequestsStatus/components/ApiDimmer.test.js
+++ b/app/modules/apiRequestsStatus/components/ApiDimmer.test.js
@@ -2,12 +2,8 @@
 
 import * as React from 'react';
 import { shallow, mount } from 'enzyme';
-import { createStore } from 'redux';
-import { Provider } from 'react-redux';
-import { I18nextProvider } from 'react-i18next';
 
-import i18nextConfig from 'config/i18next';
-import { dummyProviderProps } from 'lib/testResources';
+import { DummyProviders, dummyProviderProps } from 'lib/testResources';
 
 import * as m from '../model';
 
@@ -20,9 +16,6 @@ describe(`ApiDimmer`, (): void => {
   let dummyFailureStatus: m.RequestStatus;
 
   let dummyState: any;
-
-  let dummyReducer: *;
-  let dummyStore: *;
 
   beforeEach((): void => {
     dummyPendingStatus = {
@@ -45,9 +38,6 @@ describe(`ApiDimmer`, (): void => {
         },
       },
     };
-
-    dummyReducer = (state: any = {}, action: any): any => state;
-    dummyStore = createStore(dummyReducer, dummyState);
   });
 
   it(`renders without errors`, (): void => {
@@ -90,13 +80,11 @@ describe(`ApiDimmer`, (): void => {
 
   it(`is active, when the requestStatus for a single passed requestId is PENDING`, (): void => {
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <I18nextProvider i18n={i18nextConfig}>
-          <ApiDimmer requestIds={['pendingRequestId', 'failureRequestId', 'successRequestId']}>
-            <p data-test-id="enzyme">test.is.active</p>
-          </ApiDimmer>
-        </I18nextProvider>
-      </Provider>,
+      <DummyProviders dummyState={dummyState}>
+        <ApiDimmer requestIds={['pendingRequestId', 'failureRequestId', 'successRequestId']}>
+          <p data-test-id="enzyme">test.is.active</p>
+        </ApiDimmer>
+      </DummyProviders>,
     );
 
     expect(enzymeWrapper.find('[data-test-id="enzyme"]').text()).toBe('test.is.active');
@@ -104,13 +92,11 @@ describe(`ApiDimmer`, (): void => {
 
   it(`is not active, when the requestStatus none of the passed requestIds is PENDING`, (): void => {
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <I18nextProvider i18n={i18nextConfig}>
-          <ApiDimmer requestIds={['failureRequestId', 'successRequestId']}>
-            <p data-test-id="enzyme">test.is.active</p>
-          </ApiDimmer>
-        </I18nextProvider>
-      </Provider>,
+      <DummyProviders dummyState={dummyState}>
+        <ApiDimmer requestIds={['failureRequestId', 'successRequestId']}>
+          <p data-test-id="enzyme">test.is.active</p>
+        </ApiDimmer>
+      </DummyProviders>,
     );
 
     expect(enzymeWrapper.find('PureApiDimmer').isEmptyRender()).toEqual(true);
@@ -118,13 +104,11 @@ describe(`ApiDimmer`, (): void => {
 
   it(`ignores invalid requestIds`, (): void => {
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <I18nextProvider i18n={i18nextConfig}>
-          <ApiDimmer requestIds={['failureRequestId', 'successRequestId', 'invalidRequestId']}>
-            <p data-test-id="enzyme">test.is.active</p>
-          </ApiDimmer>
-        </I18nextProvider>
-      </Provider>,
+      <DummyProviders dummyState={dummyState}>
+        <ApiDimmer requestIds={['failureRequestId', 'successRequestId', 'invalidRequestId']}>
+          <p data-test-id="enzyme">test.is.active</p>
+        </ApiDimmer>
+      </DummyProviders>,
     );
 
     expect(enzymeWrapper.find('PureApiDimmer').isEmptyRender()).toEqual(true);

--- a/app/modules/contentItems/components/EditableDisplay/index.test.js
+++ b/app/modules/contentItems/components/EditableDisplay/index.test.js
@@ -1,12 +1,10 @@
 // @flow
 
 import * as React from 'react';
-import { createStore } from 'redux';
-import { Provider } from 'react-redux';
 import { mount, shallow } from 'enzyme';
 
 import { ObjectNotFoundError } from 'errors';
-import { dummyContentItemData as dummyData } from 'lib/testResources';
+import { DummyProviders, dummyContentItemData as dummyData } from 'lib/testResources';
 
 import actions from '../../actions';
 import * as m from '../../model';
@@ -29,9 +27,6 @@ describe(`EditableDisplay`, (): void => {
 
   let dummyDispatchProps: DispatchProps;
   let subItemsSelector: string;
-
-  let dummyReducer: *;
-  let dummyStore: *;
 
   beforeEach((): void => {
     dummyRoot2 = { ...dummyData.rootContentItem2 };
@@ -71,9 +66,6 @@ describe(`EditableDisplay`, (): void => {
       onReverseIndent: jest.fn(),
     };
     subItemsSelector = `[data-test-id="content-item-editable-display__sub-items"]`;
-
-    dummyReducer = (state: any = {}, action: any): any => state;
-    dummyStore = createStore(dummyReducer, dummyState);
   });
 
   it(`renders without errors`, (): void => {
@@ -135,22 +127,22 @@ describe(`EditableDisplay`, (): void => {
     console.error = jest.fn();
     expect((): void => {
       mount(
-        <Provider store={dummyStore}>
+        <DummyProviders dummyState={dummyState}>
           <EditableDisplay
             contentItemId="DefinitelyNotValidId"
           />
-        </Provider>,
+        </DummyProviders>,
       );
     }).toThrow(ObjectNotFoundError);
   });
 
   it(`renders all of the contentItem's sub items, when the contentItem is subable and has sub items`, (): void => {
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
+      <DummyProviders dummyState={dummyState}>
         <EditableDisplay
           contentItemId={dummyRoot1.id}
         />
-      </Provider>,
+      </DummyProviders>,
     );
 
     const subItemsTags = enzymeWrapper.find(subItemsSelector).hostNodes();
@@ -173,11 +165,11 @@ describe(`EditableDisplay`, (): void => {
 
   it(`does not render an empty sub items container, when the contentItem is not subable`, (): void => {
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
+      <DummyProviders dummyState={dummyState}>
         <EditableDisplay
           contentItemId={dummyRoot2.id}
         />
-      </Provider>,
+      </DummyProviders>,
     );
     const subItemsTags = enzymeWrapper.find(subItemsSelector).hostNodes();
     expect(subItemsTags).toHaveLength(0);
@@ -185,11 +177,11 @@ describe(`EditableDisplay`, (): void => {
 
   it(`does not render an empty sub items container, when the contentItem is subable but does not contain any sub items`, (): void => {
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
+      <DummyProviders dummyState={dummyState}>
         <EditableDisplay
           contentItemId={dummyParagraph111.id}
         />
-      </Provider>,
+      </DummyProviders>,
     );
     const subItemsTags = enzymeWrapper.find(subItemsSelector).hostNodes();
     expect(subItemsTags).toHaveLength(0);

--- a/app/modules/contentItems/components/EditableDisplay/typesToComponentsMap/Root.test.js
+++ b/app/modules/contentItems/components/EditableDisplay/typesToComponentsMap/Root.test.js
@@ -1,11 +1,9 @@
 // @flow
 
 import * as React from 'react';
-import { createStore } from 'redux';
-import { Provider } from 'react-redux';
 import { mount, shallow } from 'enzyme';
 
-import { dummyContentItemData as dummyData } from 'lib/testResources';
+import { DummyProviders, dummyContentItemData as dummyData } from 'lib/testResources';
 
 import * as m from '../../../model';
 
@@ -18,9 +16,6 @@ describe(`Root`, (): void => {
   let dummyRoot: $Exact<m.RootContentItem>;
   let dummyContentItemsById: $Exact<m.ContentItemsById>;
   let dummyState: any;
-
-  let dummyReducer: *;
-  let dummyStore: *;
 
   beforeEach((): void => {
     dummyHeading2 = { ...dummyData.headingContentItem2 };
@@ -38,9 +33,6 @@ describe(`Root`, (): void => {
         },
       },
     };
-
-    dummyReducer = (state: any = {}, action: any): any => state;
-    dummyStore = createStore(dummyReducer, dummyState);
   });
 
   it(`renders without errors`, (): void => {
@@ -52,9 +44,9 @@ describe(`Root`, (): void => {
 
   it(`renders all of its child items`, (): void => {
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
+      <DummyProviders dummyState={dummyState}>
         <PureRoot contentItem={dummyRoot} />
-      </Provider>,
+      </DummyProviders>,
     );
     expect(enzymeWrapper.find('PureHeading')).toHaveLength(2);
   });

--- a/app/modules/platform/components/AuthWrapper/index.test.js
+++ b/app/modules/platform/components/AuthWrapper/index.test.js
@@ -1,26 +1,16 @@
 // @flow
 
 import * as React from 'react';
-import { createStore } from 'redux';
-import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
 import { shallow, mount } from 'enzyme';
 
 import { AUTH_SIGNIN_ROUTE } from 'config/routes';
+import { DummyProviders } from 'lib/testResources';
 
 import selectors from '../../selectors';
 
 import AuthWrapper, { PureAuthWrapper } from '.';
 
 describe(`AuthWrapper`, (): void => {
-
-  let dummyReducer: *;
-  let dummyStore: *;
-
-  beforeEach((): void => {
-    dummyReducer = (state: any = {}, action: any): any => state;
-    dummyStore = createStore(dummyReducer, {});
-  });
 
   it(`renders without errors`, (): void => {
     const enzymeWrapper = shallow(
@@ -35,14 +25,12 @@ describe(`AuthWrapper`, (): void => {
     selectors.isAuthenticated = (jest.fn((): boolean => true): any);
 
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <MemoryRouter>
-          <AuthWrapper>
-            <p>Secure text</p>
-            <p>More secure text</p>
-          </AuthWrapper>
-        </MemoryRouter>
-      </Provider>,
+      <DummyProviders>
+        <AuthWrapper>
+          <p>Secure text</p>
+          <p>More secure text</p>
+        </AuthWrapper>
+      </DummyProviders>,
     );
     const conditionalWrapper = enzymeWrapper.find('PureConditionalWrapper');
 
@@ -55,14 +43,12 @@ describe(`AuthWrapper`, (): void => {
     selectors.isAuthenticated = (jest.fn((): boolean => false): any);
 
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <MemoryRouter>
-          <AuthWrapper>
-            <p>Secure text</p>
-            <p>More secure text</p>
-          </AuthWrapper>
-        </MemoryRouter>
-      </Provider>,
+      <DummyProviders>
+        <AuthWrapper>
+          <p>Secure text</p>
+          <p>More secure text</p>
+        </AuthWrapper>
+      </DummyProviders>,
     );
     const conditionalWrapper = enzymeWrapper.find('PureConditionalWrapper');
 
@@ -75,14 +61,12 @@ describe(`AuthWrapper`, (): void => {
     selectors.isAuthenticated = (jest.fn((): boolean => false): any);
 
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <MemoryRouter>
-          <AuthWrapper redirectIfNotAuthenticated="/dummyRoute">
-            <p>Secure text</p>
-            <p>More secure text</p>
-          </AuthWrapper>
-        </MemoryRouter>
-      </Provider>,
+      <DummyProviders>
+        <AuthWrapper redirectIfNotAuthenticated="/dummyRoute">
+          <p>Secure text</p>
+          <p>More secure text</p>
+        </AuthWrapper>
+      </DummyProviders>,
     );
     const conditionalWrapper = enzymeWrapper.find('PureConditionalWrapper');
 
@@ -95,14 +79,12 @@ describe(`AuthWrapper`, (): void => {
     const DummyComponent = (): React.Node => <p>dummy</p>;
 
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <MemoryRouter>
-          <AuthWrapper componentIfNotAuthenticated={DummyComponent}>
-            <p>Secure text</p>
-            <p>More secure text</p>
-          </AuthWrapper>
-        </MemoryRouter>
-      </Provider>,
+      <DummyProviders>
+        <AuthWrapper componentIfNotAuthenticated={DummyComponent}>
+          <p>Secure text</p>
+          <p>More secure text</p>
+        </AuthWrapper>
+      </DummyProviders>,
     );
     const conditionalWrapper = enzymeWrapper.find('PureConditionalWrapper');
 

--- a/app/modules/platform/components/ResendConfirmationEmailCard/index.test.js
+++ b/app/modules/platform/components/ResendConfirmationEmailCard/index.test.js
@@ -2,14 +2,9 @@
 
 import * as React from 'react';
 import { shallow, mount } from 'enzyme';
-import { createStore } from 'redux';
-import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
-import { I18nextProvider } from 'react-i18next';
 
 import { InvalidArgumentError } from 'errors';
-import i18nextConfig from 'config/i18next';
-import { dummyProviderProps } from 'lib/testResources';
+import { DummyProviders, dummyProviderProps } from 'lib/testResources';
 
 import actions from '../../actions';
 
@@ -18,18 +13,11 @@ import ResendConfirmationEmailCard, { PureResendConfirmationEmailCard } from '.'
 describe(`ResendConfirmationEmailCard`, (): void => {
 
   let dummyEmail: string;
-
   let dummyDispatch: *;
-  let dummyReducer: *;
-  let dummyStore: *;
 
   beforeEach((): void => {
     dummyEmail = 'test@test.be';
-
     dummyDispatch = jest.fn();
-    dummyReducer = (state: any = {}, action: any): any => state;
-    dummyStore = createStore(dummyReducer, {});
-    dummyStore.dispatch = dummyDispatch;
   });
 
   it(`renders without errors`, (): void => {
@@ -41,13 +29,9 @@ describe(`ResendConfirmationEmailCard`, (): void => {
 
   it(`dispatches a resendConfirmationEmail action, when its form is submitted with complete values`, (): void => {
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <I18nextProvider i18n={i18nextConfig}>
-          <MemoryRouter>
-            <ResendConfirmationEmailCard />
-          </MemoryRouter>
-        </I18nextProvider>
-      </Provider>,
+      <DummyProviders dummyDispatch={dummyDispatch}>
+        <ResendConfirmationEmailCard />
+      </DummyProviders>,
     );
     const onEmailFormSubmit = enzymeWrapper.find('PureResendConfirmationEmailCard').props().onEmailFormSubmit;
 
@@ -57,13 +41,9 @@ describe(`ResendConfirmationEmailCard`, (): void => {
 
   it(`throws an InvalidArgumentError, when its form is submitted with incomplete values`, (): void => {
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <I18nextProvider i18n={i18nextConfig}>
-          <MemoryRouter>
-            <ResendConfirmationEmailCard />
-          </MemoryRouter>
-        </I18nextProvider>
-      </Provider>,
+      <DummyProviders dummyDispatch={dummyDispatch}>
+        <ResendConfirmationEmailCard />
+      </DummyProviders>,
     );
     const onEmailFormSubmit = enzymeWrapper.find('PureResendConfirmationEmailCard').props().onEmailFormSubmit;
 

--- a/app/modules/platform/components/ResetPasswordCard/index.test.js
+++ b/app/modules/platform/components/ResetPasswordCard/index.test.js
@@ -2,14 +2,9 @@
 
 import * as React from 'react';
 import { shallow, mount } from 'enzyme';
-import { createStore } from 'redux';
-import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
-import { I18nextProvider } from 'react-i18next';
 
 import { InvalidArgumentError } from 'errors';
-import i18nextConfig from 'config/i18next';
-import { dummyProviderProps } from 'lib/testResources';
+import { DummyProviders, dummyProviderProps } from 'lib/testResources';
 
 import actions from '../../actions';
 
@@ -18,18 +13,11 @@ import ResetPasswordCard, { PureResetPasswordCard } from '.';
 describe(`ResetPasswordCard`, (): void => {
 
   let dummyEmail: string;
-
   let dummyDispatch: *;
-  let dummyReducer: *;
-  let dummyStore: *;
 
   beforeEach((): void => {
     dummyEmail = 'test@test.be';
-
     dummyDispatch = jest.fn();
-    dummyReducer = (state: any = {}, action: any): any => state;
-    dummyStore = createStore(dummyReducer, {});
-    dummyStore.dispatch = dummyDispatch;
   });
 
   it(`renders without errors`, (): void => {
@@ -41,13 +29,9 @@ describe(`ResetPasswordCard`, (): void => {
 
   it(`dispatches a resetPassword action, when its form is submitted with complete values`, (): void => {
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <I18nextProvider i18n={i18nextConfig}>
-          <MemoryRouter>
-            <ResetPasswordCard />
-          </MemoryRouter>
-        </I18nextProvider>
-      </Provider>,
+      <DummyProviders dummyDispatch={dummyDispatch}>
+        <ResetPasswordCard />
+      </DummyProviders>,
     );
     const onEmailFormSubmit = enzymeWrapper.find('PureResetPasswordCard').props().onEmailFormSubmit;
 
@@ -57,13 +41,9 @@ describe(`ResetPasswordCard`, (): void => {
 
   it(`throws an InvalidArgumentError, when its form is submitted with incomplete values`, (): void => {
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <I18nextProvider i18n={i18nextConfig}>
-          <MemoryRouter>
-            <ResetPasswordCard />
-          </MemoryRouter>
-        </I18nextProvider>
-      </Provider>,
+      <DummyProviders dummyDispatch={dummyDispatch}>
+        <ResetPasswordCard />
+      </DummyProviders>,
     );
     const onEmailFormSubmit = enzymeWrapper.find('PureResetPasswordCard').props().onEmailFormSubmit;
 

--- a/app/modules/platform/components/Sidebars/index.test.js
+++ b/app/modules/platform/components/Sidebars/index.test.js
@@ -2,13 +2,8 @@
 
 import * as React from 'react';
 import { shallow, mount } from 'enzyme';
-import { createStore } from 'redux';
-import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
-import { I18nextProvider } from 'react-i18next';
 
-import i18nextConfig from 'config/i18next';
-import { dummyTopicData, dummyContentItemData } from 'lib/testResources';
+import { DummyProviders, dummyTopicData, dummyContentItemData } from 'lib/testResources';
 import topics from 'modules/topics';
 
 import * as m from '../../model';
@@ -19,10 +14,7 @@ describe(`Sidebars`, (): void => {
 
   let dummyTopic: topics.model.Topic;
   let dummyState: any;
-
   let dummyDispatch: *;
-  let dummyReducer: *;
-  let dummyStore: *;
 
   beforeEach((): void => {
     dummyTopic = { ...dummyTopicData.topic, rootContentItemId: dummyContentItemData.rootContentItem.id };
@@ -45,11 +37,7 @@ describe(`Sidebars`, (): void => {
         },
       },
     };
-
     dummyDispatch = jest.fn();
-    dummyReducer = (state: any = {}, action: any): any => state;
-    dummyStore = createStore(dummyReducer, dummyState);
-    dummyStore.dispatch = dummyDispatch;
   });
 
   it(`renders without errors`, (): void => {
@@ -65,13 +53,9 @@ describe(`Sidebars`, (): void => {
 
   it(`renders all active sidebars in reverse order`, (): void => {
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <I18nextProvider i18n={i18nextConfig}>
-          <MemoryRouter>
-            <Sidebars topicId={dummyTopic.id} />
-          </MemoryRouter>
-        </I18nextProvider>
-      </Provider>,
+      <DummyProviders dummyState={dummyState} dummyDispatch={dummyDispatch}>
+        <Sidebars topicId={dummyTopic.id} />
+      </DummyProviders>,
     );
 
     const sidebarsGridItemNodes = enzymeWrapper.find('[data-test-id="sidebars-grid-item"]');

--- a/app/modules/platform/components/SidebarsMenu/SidebarsMenuItem/index.test.js
+++ b/app/modules/platform/components/SidebarsMenu/SidebarsMenuItem/index.test.js
@@ -2,13 +2,8 @@
 
 import * as React from 'react';
 import { shallow, mount } from 'enzyme';
-import { createStore } from 'redux';
-import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
-import { I18nextProvider } from 'react-i18next';
 
-import i18nextConfig from 'config/i18next';
-import { dummyProviderProps } from 'lib/testResources';
+import { DummyProviders, dummyProviderProps } from 'lib/testResources';
 
 import actions from '../../../actions';
 import * as m from '../../../model';
@@ -19,18 +14,11 @@ import SidebarsMenuItem, { PureSidebarsMenuItem } from '.';
 describe(`SidebarsMenuItem`, (): void => {
 
   let dummySidebarId: m.SidebarId;
-
   let dummyDispatch: *;
-  let dummyReducer: *;
-  let dummyStore: *;
 
   beforeEach((): void => {
     dummySidebarId = m.sidebarIds.TOPIC_INFO;
-
     dummyDispatch = jest.fn();
-    dummyReducer = (state: any = {}, action: any): any => state;
-    dummyStore = createStore(dummyReducer, {});
-    dummyStore.dispatch = dummyDispatch;
   });
 
   it(`renders without errors`, (): void => {
@@ -49,13 +37,9 @@ describe(`SidebarsMenuItem`, (): void => {
     selectors.getSettingByKey = (): any => [dummySidebarId];
 
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <I18nextProvider i18n={i18nextConfig}>
-          <MemoryRouter>
-            <SidebarsMenuItem sidebarId={dummySidebarId} />
-          </MemoryRouter>
-        </I18nextProvider>
-      </Provider>,
+      <DummyProviders dummyDispatch={dummyDispatch}>
+        <SidebarsMenuItem sidebarId={dummySidebarId} />
+      </DummyProviders>,
     );
 
     expect(enzymeWrapper.find('PureSidebarsMenuItem').props().isActive).toBe(true);
@@ -65,13 +49,9 @@ describe(`SidebarsMenuItem`, (): void => {
     selectors.getSettingByKey = (): any => [];
 
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <I18nextProvider i18n={i18nextConfig}>
-          <MemoryRouter>
-            <SidebarsMenuItem sidebarId={dummySidebarId} />
-          </MemoryRouter>
-        </I18nextProvider>
-      </Provider>,
+      <DummyProviders dummyDispatch={dummyDispatch}>
+        <SidebarsMenuItem sidebarId={dummySidebarId} />
+      </DummyProviders>,
     );
 
     expect(enzymeWrapper.find('PureSidebarsMenuItem').props().isActive).toBe(false);
@@ -81,13 +61,9 @@ describe(`SidebarsMenuItem`, (): void => {
     selectors.getSettingByKey = (): any => [dummySidebarId];
 
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <I18nextProvider i18n={i18nextConfig}>
-          <MemoryRouter>
-            <SidebarsMenuItem sidebarId={dummySidebarId} />
-          </MemoryRouter>
-        </I18nextProvider>
-      </Provider>,
+      <DummyProviders dummyDispatch={dummyDispatch}>
+        <SidebarsMenuItem sidebarId={dummySidebarId} />
+      </DummyProviders>,
     );
 
     const menuItemNode = enzymeWrapper.find('[data-test-id="sidebars-menu-item"]').hostNodes();

--- a/app/modules/platform/components/SigninCard/index.test.js
+++ b/app/modules/platform/components/SigninCard/index.test.js
@@ -2,14 +2,9 @@
 
 import * as React from 'react';
 import { shallow, mount } from 'enzyme';
-import { createStore } from 'redux';
-import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
-import { I18nextProvider } from 'react-i18next';
 
 import { InvalidArgumentError } from 'errors';
-import i18nextConfig from 'config/i18next';
-import { dummyProviderProps } from 'lib/testResources';
+import { DummyProviders, dummyProviderProps } from 'lib/testResources';
 
 import actions from '../../actions';
 
@@ -21,19 +16,14 @@ describe(`SigninCard`, (): void => {
   let dummyPassword: string;
 
   let dummyDispatch: *;
-  let dummyReducer: *;
   let dummyState: *;
-  let dummyStore: *;
 
   beforeEach((): void => {
     dummyEmail = 'test@test.be';
     dummyPassword = 'MahPasswordY0';
 
     dummyDispatch = jest.fn();
-    dummyReducer = (state: any = {}, action: any): any => state;
     dummyState = { modules: { apiRequestsStatus: {} } };
-    dummyStore = createStore(dummyReducer, dummyState);
-    dummyStore.dispatch = dummyDispatch;
   });
 
   it(`renders without errors`, (): void => {
@@ -45,13 +35,9 @@ describe(`SigninCard`, (): void => {
 
   it(`dispatches a signin action, when its form is submitted with complete values`, (): void => {
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <I18nextProvider i18n={i18nextConfig}>
-          <MemoryRouter>
-            <SigninCard />
-          </MemoryRouter>
-        </I18nextProvider>
-      </Provider>,
+      <DummyProviders dummyState={dummyState} dummyDispatch={dummyDispatch}>
+        <SigninCard />
+      </DummyProviders>,
     );
     const onEmailAndPasswordFormSubmit = enzymeWrapper.find('PureSigninCard').props().onEmailAndPasswordFormSubmit;
 
@@ -61,13 +47,9 @@ describe(`SigninCard`, (): void => {
 
   it(`throws an InvalidArgumentError, when its form is submitted with incomplete values`, (): void => {
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <I18nextProvider i18n={i18nextConfig}>
-          <MemoryRouter>
-            <SigninCard />
-          </MemoryRouter>
-        </I18nextProvider>
-      </Provider>,
+      <DummyProviders dummyState={dummyState} dummyDispatch={dummyDispatch}>
+        <SigninCard />
+      </DummyProviders>,
     );
     const onEmailAndPasswordFormSubmit = enzymeWrapper.find('PureSigninCard').props().onEmailAndPasswordFormSubmit;
 

--- a/app/modules/platform/components/SignupCard/index.test.js
+++ b/app/modules/platform/components/SignupCard/index.test.js
@@ -2,14 +2,9 @@
 
 import * as React from 'react';
 import { shallow, mount } from 'enzyme';
-import { createStore } from 'redux';
-import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
-import { I18nextProvider } from 'react-i18next';
 
 import { InvalidArgumentError } from 'errors';
-import i18nextConfig from 'config/i18next';
-import { dummyProviderProps } from 'lib/testResources';
+import { DummyProviders, dummyProviderProps } from 'lib/testResources';
 
 import actions from '../../actions';
 
@@ -24,8 +19,6 @@ describe(`SignupCard`, (): void => {
   let dummyTosAccepted: boolean;
 
   let dummyDispatch: *;
-  let dummyReducer: *;
-  let dummyStore: *;
 
   beforeEach((): void => {
     dummyEmail = 'test@test.be';
@@ -35,9 +28,6 @@ describe(`SignupCard`, (): void => {
     dummyTosAccepted = true;
 
     dummyDispatch = jest.fn();
-    dummyReducer = (state: any = {}, action: any): any => state;
-    dummyStore = createStore(dummyReducer, {});
-    dummyStore.dispatch = dummyDispatch;
   });
 
   it(`renders without errors`, (): void => {
@@ -49,13 +39,9 @@ describe(`SignupCard`, (): void => {
 
   it(`dispatches a signup action, when its form is submitted with complete values`, (): void => {
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <I18nextProvider i18n={i18nextConfig}>
-          <MemoryRouter>
-            <SignupCard />
-          </MemoryRouter>
-        </I18nextProvider>
-      </Provider>,
+      <DummyProviders dummyDispatch={dummyDispatch}>
+        <SignupCard />
+      </DummyProviders>,
     );
     const onUserFormSubmit = enzymeWrapper.find('PureSignupCard').props().onUserFormSubmit;
 
@@ -65,13 +51,9 @@ describe(`SignupCard`, (): void => {
 
   it(`throws an InvalidArgumentError, when its form is submitted with incomplete values`, (): void => {
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <I18nextProvider i18n={i18nextConfig}>
-          <MemoryRouter>
-            <SignupCard />
-          </MemoryRouter>
-        </I18nextProvider>
-      </Provider>,
+      <DummyProviders dummyDispatch={dummyDispatch}>
+        <SignupCard />
+      </DummyProviders>,
     );
     const onUserFormSubmit = enzymeWrapper.find('PureSignupCard').props().onUserFormSubmit;
 

--- a/app/modules/platform/components/UnauthWrapper/index.test.js
+++ b/app/modules/platform/components/UnauthWrapper/index.test.js
@@ -1,24 +1,15 @@
 // @flow
 
 import * as React from 'react';
-import { createStore } from 'redux';
-import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
 import { shallow, mount } from 'enzyme';
+
+import { DummyProviders } from 'lib/testResources';
 
 import selectors from '../../selectors';
 
 import UnauthWrapper, { PureUnauthWrapper } from '.';
 
 describe(`UnauthWrapper`, (): void => {
-
-  let dummyReducer: *;
-  let dummyStore: *;
-
-  beforeEach((): void => {
-    dummyReducer = (state: any = {}, action: any): any => state;
-    dummyStore = createStore(dummyReducer, {});
-  });
 
   it(`renders without errors`, (): void => {
     const enzymeWrapper = shallow(
@@ -33,14 +24,12 @@ describe(`UnauthWrapper`, (): void => {
     selectors.isAuthenticated = (jest.fn((): boolean => false): any);
 
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <MemoryRouter>
-          <UnauthWrapper>
-            <p>Secure text</p>
-            <p>More secure text</p>
-          </UnauthWrapper>
-        </MemoryRouter>
-      </Provider>,
+      <DummyProviders>
+        <UnauthWrapper>
+          <p>Secure text</p>
+          <p>More secure text</p>
+        </UnauthWrapper>
+      </DummyProviders>,
     );
     const conditionalWrapper = enzymeWrapper.find('PureConditionalWrapper');
 
@@ -53,14 +42,12 @@ describe(`UnauthWrapper`, (): void => {
     selectors.isAuthenticated = (jest.fn((): boolean => true): any);
 
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <MemoryRouter>
-          <UnauthWrapper>
-            <p>Secure text</p>
-            <p>More secure text</p>
-          </UnauthWrapper>
-        </MemoryRouter>
-      </Provider>,
+      <DummyProviders>
+        <UnauthWrapper>
+          <p>Secure text</p>
+          <p>More secure text</p>
+        </UnauthWrapper>
+      </DummyProviders>,
     );
     const conditionalWrapper = enzymeWrapper.find('PureConditionalWrapper');
 
@@ -73,14 +60,12 @@ describe(`UnauthWrapper`, (): void => {
     selectors.isAuthenticated = (jest.fn((): boolean => true): any);
 
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <MemoryRouter>
-          <UnauthWrapper redirectIfAuthenticated="/dummyRoute">
-            <p>Secure text</p>
-            <p>More secure text</p>
-          </UnauthWrapper>
-        </MemoryRouter>
-      </Provider>,
+      <DummyProviders>
+        <UnauthWrapper redirectIfAuthenticated="/dummyRoute">
+          <p>Secure text</p>
+          <p>More secure text</p>
+        </UnauthWrapper>
+      </DummyProviders>,
     );
     const conditionalWrapper = enzymeWrapper.find('PureConditionalWrapper');
 
@@ -93,14 +78,12 @@ describe(`UnauthWrapper`, (): void => {
     const DummyComponent = (): React.Node => <p>dummy</p>;
 
     const enzymeWrapper = mount(
-      <Provider store={dummyStore}>
-        <MemoryRouter>
-          <UnauthWrapper componentIfAuthenticated={DummyComponent}>
-            <p>Secure text</p>
-            <p>More secure text</p>
-          </UnauthWrapper>
-        </MemoryRouter>
-      </Provider>,
+      <DummyProviders>
+        <UnauthWrapper componentIfAuthenticated={DummyComponent}>
+          <p>Secure text</p>
+          <p>More secure text</p>
+        </UnauthWrapper>
+      </DummyProviders>,
     );
     const conditionalWrapper = enzymeWrapper.find('PureConditionalWrapper');
 


### PR DESCRIPTION
Added `DummyProviders` component, which makes it much easier to test components that have been `mount`ed. Updated existing tests to use `DummyProviders` instead of manually creating all necessary providers.