### PR TITLE
API versioning

### DIFF
--- a/app/config/api.js
+++ b/app/config/api.js
@@ -2,3 +2,6 @@
 
 // API base URL
 export const API_URL = (window.config ? window.config.API_URL : 'http://owsdev.ugent.be/api');
+
+// API version
+export const API_VERSION = '2.0.0';

--- a/app/lib/ApiRequest/ApiRequest/index.js
+++ b/app/lib/ApiRequest/ApiRequest/index.js
@@ -4,7 +4,7 @@
 
 import _ from 'lodash';
 
-import { API_URL } from 'config/api';
+import { API_URL, API_VERSION } from 'config/api';
 import { InvalidArgumentError, UnsupportedOperationError } from 'errors';
 
 import {
@@ -15,14 +15,17 @@ import {
 import fetchApiResponseData from './fetchApiResponseData';
 
 // JSON API media type
-const MEDIA_TYPE = 'application/vnd.api+json';
+const JSONAPI_MEDIA_TYPE = 'application/vnd.api+json';
+
+// Open Webslides API media type, including version parameter
+const OWS_MEDIA_TYPE = `application/vnd.openwebslides+json; version=${API_VERSION}`;
 
 const defaultConfig = {
   apiUrl: API_URL,
   pathSegments: [],
   headers: {
-    'Content-Type': MEDIA_TYPE,
-    'Accept': MEDIA_TYPE,
+    'Content-Type': JSONAPI_MEDIA_TYPE,
+    'Accept': `${JSONAPI_MEDIA_TYPE}, ${OWS_MEDIA_TYPE}`,
   },
   parameters: {},
   body: null,
@@ -111,5 +114,5 @@ class ApiRequest {
   };
 }
 
-export { MEDIA_TYPE, defaultConfig };
+export { JSONAPI_MEDIA_TYPE, OWS_MEDIA_TYPE, defaultConfig };
 export default ApiRequest;


### PR DESCRIPTION
Adds a version number to every API request.

This is necessary for API versions >= 2.0.0, that will not honour requests without or with an incompatible version number. This change is backwards compatible.