### PR TITLE
Fix unexpected JSON

### DIFF
--- a/app/api/confirmation/post.test.js
+++ b/app/api/confirmation/post.test.js
@@ -13,7 +13,7 @@ describe(`api.confirmation.post`, (): void => {
 
   it(`executes the correct fetch call`, async (): Promise<mixed> => {
     const dummyConfirmationToken = 'foobarToken';
-    fetch.mockResponseOnce(null, { status: 200 });
+    fetch.mockResponseOnce('', { status: 200 });
     await api.confirmation.post(dummyConfirmationToken);
 
     expect(fetch.mock.calls).toHaveLength(1);

--- a/app/api/confirmation/postEmail.test.js
+++ b/app/api/confirmation/postEmail.test.js
@@ -13,7 +13,7 @@ describe(`api.confirmation.postEmail`, (): void => {
 
   it(`executes the correct fetch call`, async (): Promise<mixed> => {
     const dummyEmail = 'test@test.be';
-    fetch.mockResponseOnce(null, { status: 200 });
+    fetch.mockResponseOnce('', { status: 200 });
     await api.confirmation.postEmail(dummyEmail);
 
     expect(fetch.mock.calls).toHaveLength(1);

--- a/app/api/notifications/getAll.test.js
+++ b/app/api/notifications/getAll.test.js
@@ -12,7 +12,7 @@ describe(`api.notifications.getAll`, (): void => {
   });
 
   it(`executes the correct fetch call`, async (): Promise<mixed> => {
-    fetch.mockResponseOnce(null, { status: 200 });
+    fetch.mockResponseOnce('', { status: 200 });
     await api.notifications.getAll();
 
     expect(fetch.mock.calls).toHaveLength(1);

--- a/app/api/password/postEmail.test.js
+++ b/app/api/password/postEmail.test.js
@@ -13,7 +13,7 @@ describe(`api.password.postEmail`, (): void => {
 
   it(`executes the correct fetch call`, async (): Promise<mixed> => {
     const dummyEmail = 'test@test.be';
-    fetch.mockResponseOnce(null, { status: 200 });
+    fetch.mockResponseOnce('', { status: 200 });
     await api.password.postEmail(dummyEmail);
 
     expect(fetch.mock.calls).toHaveLength(1);

--- a/app/api/token/delete.test.js
+++ b/app/api/token/delete.test.js
@@ -13,7 +13,7 @@ describe(`api.token.delete`, (): void => {
 
   it(`executes the correct fetch call`, async (): Promise<mixed> => {
     const dummyToken = 'foobarToken';
-    fetch.mockResponseOnce(null, { status: 200 });
+    fetch.mockResponseOnce('', { status: 200 });
     await api.token.delete(dummyToken);
 
     expect(fetch.mock.calls).toHaveLength(1);

--- a/app/api/token/postSignin.test.js
+++ b/app/api/token/postSignin.test.js
@@ -14,7 +14,7 @@ describe(`api.token.postSignin`, (): void => {
   it(`executes the correct fetch call`, async (): Promise<mixed> => {
     const dummyEmail = 'test@test.be';
     const dummyPassword = 'mahpasswordy0';
-    fetch.mockResponseOnce(null, { status: 200 });
+    fetch.mockResponseOnce('', { status: 200 });
     await api.token.postSignin(dummyEmail, dummyPassword);
 
     expect(fetch.mock.calls).toHaveLength(1);

--- a/app/api/topics/delete.test.js
+++ b/app/api/topics/delete.test.js
@@ -14,7 +14,7 @@ describe(`api.topics.delete`, (): void => {
   it(`executes the correct fetch call`, async (): Promise<mixed> => {
     const dummyTopicId = 'ThisIsAnId';
     const dummyToken = 'foobarToken';
-    fetch.mockResponseOnce(null, { status: 200 });
+    fetch.mockResponseOnce('', { status: 200 });
     await api.topics.delete(dummyTopicId, dummyToken);
 
     expect(fetch.mock.calls).toHaveLength(1);

--- a/app/api/topics/get.test.js
+++ b/app/api/topics/get.test.js
@@ -13,7 +13,7 @@ describe(`api.topics.get`, (): void => {
 
   it(`executes the correct fetch call`, async (): Promise<mixed> => {
     const dummyTopicId = 'ThisIsAnId';
-    fetch.mockResponseOnce(null, { status: 200 });
+    fetch.mockResponseOnce('', { status: 200 });
     await api.topics.get(dummyTopicId);
 
     expect(fetch.mock.calls).toHaveLength(1);

--- a/app/api/topics/getAllByUserId.test.js
+++ b/app/api/topics/getAllByUserId.test.js
@@ -13,7 +13,7 @@ describe(`api.topics.getAllByUserId`, (): void => {
 
   it(`executes the correct fetch call`, async (): Promise<mixed> => {
     const dummyUserId = 'ThisIsAnId';
-    fetch.mockResponseOnce(null, { status: 200 });
+    fetch.mockResponseOnce('', { status: 200 });
     await api.topics.getAllByUserId(dummyUserId);
 
     expect(fetch.mock.calls).toHaveLength(1);

--- a/app/api/topics/getContent.test.js
+++ b/app/api/topics/getContent.test.js
@@ -14,7 +14,7 @@ describe(`api.topics.getContent`, (): void => {
   it(`executes the correct fetch call`, async (): Promise<mixed> => {
     const dummyTopicId = 'ThisIsAnId';
     const dummyToken = 'foobarToken';
-    fetch.mockResponseOnce(null, { status: 200 });
+    fetch.mockResponseOnce('', { status: 200 });
     await api.topics.getContent(dummyTopicId, dummyToken);
 
     expect(fetch.mock.calls).toHaveLength(1);

--- a/app/api/topics/patchContent.test.js
+++ b/app/api/topics/patchContent.test.js
@@ -16,7 +16,7 @@ describe(`api.topics.patchContent`, (): void => {
     const dummyTopicId = 'ThisIsAnId';
     const dummyToken = 'foobarToken';
     const dummyContent = [dummyData.rootContentItem, dummyData.headingContentItem];
-    fetch.mockResponseOnce(null, { status: 200 });
+    fetch.mockResponseOnce('', { status: 200 });
     await api.topics.patchContent(dummyTopicId, dummyContent, dummyToken);
 
     expect(fetch.mock.calls).toHaveLength(1);

--- a/app/api/topics/post.test.js
+++ b/app/api/topics/post.test.js
@@ -16,7 +16,7 @@ describe(`api.topics.post`, (): void => {
     const dummyTitle = 'Lorem ipsum dolor sit amet';
     const dummyDescription = 'Topic description goes here';
     const dummyToken = 'foobarToken';
-    fetch.mockResponseOnce(null, { status: 200 });
+    fetch.mockResponseOnce('', { status: 200 });
     await api.topics.post(dummyUserId, dummyTitle, dummyDescription, dummyToken);
 
     expect(fetch.mock.calls).toHaveLength(1);

--- a/app/api/users/get.test.js
+++ b/app/api/users/get.test.js
@@ -15,7 +15,7 @@ describe(`api.users.get`, (): void => {
     const dummyUserId = 'ThisIsAnId';
     const dummyToken = 'foobarToken';
 
-    fetch.mockResponseOnce(null, { status: 200 });
+    fetch.mockResponseOnce('', { status: 200 });
     await api.users.get(dummyUserId, dummyToken);
 
     expect(fetch.mock.calls).toHaveLength(1);

--- a/app/api/users/post.test.js
+++ b/app/api/users/post.test.js
@@ -17,7 +17,7 @@ describe(`api.users.post`, (): void => {
     const dummyName = 'Test Tester';
     const dummyTosAccepted = true;
 
-    fetch.mockResponseOnce(null, { status: 200 });
+    fetch.mockResponseOnce('', { status: 200 });
     await api.users.post(dummyEmail, dummyName, dummyPassword, dummyTosAccepted);
 
     expect(fetch.mock.calls).toHaveLength(1);

--- a/app/errors/apiErrors/index.js
+++ b/app/errors/apiErrors/index.js
@@ -5,3 +5,4 @@ export { default as Http401UnauthorizedError } from './subclasses/Http401Unautho
 export { default as Http403ForbiddenError } from './subclasses/Http403ForbiddenError';
 export { default as Http422ValidationError } from './subclasses/Http422ValidationError';
 export { default as UnexpectedHttpStatusError } from './subclasses/UnexpectedHttpStatusError';
+export { default as UnexpectedEmptyResponseError } from './subclasses/UnexpectedEmptyResponseError';

--- a/app/errors/apiErrors/index.js
+++ b/app/errors/apiErrors/index.js
@@ -5,4 +5,4 @@ export { default as Http401UnauthorizedError } from './subclasses/Http401Unautho
 export { default as Http403ForbiddenError } from './subclasses/Http403ForbiddenError';
 export { default as Http422ValidationError } from './subclasses/Http422ValidationError';
 export { default as UnexpectedHttpStatusError } from './subclasses/UnexpectedHttpStatusError';
-export { default as UnexpectedEmptyResponseError } from './subclasses/UnexpectedEmptyResponseError';
+export { default as UnexpectedHttpResponseError } from './subclasses/UnexpectedHttpResponseError';

--- a/app/errors/apiErrors/subclasses/UnexpectedEmptyResponseError.js
+++ b/app/errors/apiErrors/subclasses/UnexpectedEmptyResponseError.js
@@ -7,8 +7,17 @@
 import ApiError from '../ApiError';
 
 class UnexpectedEmptyResponseError extends ApiError {
-  constructor(message: string): void {
-    super(message);
+  constructor(message: ?string = null): void {
+    let newMessage: string;
+
+    if (message == null) {
+      newMessage = 'Unexpected empty response data';
+    }
+    else {
+      newMessage = message;
+    }
+
+    super(newMessage);
 
     // Temporary workaround for https://github.com/istanbuljs/babel-plugin-istanbul/issues/143 #TODO
     /* eslint-disable no-proto */

--- a/app/errors/apiErrors/subclasses/UnexpectedEmptyResponseError.js
+++ b/app/errors/apiErrors/subclasses/UnexpectedEmptyResponseError.js
@@ -1,0 +1,23 @@
+// @flow
+
+/**
+ * An error caused by an empty HTTP response body where a response body was expected.
+ */
+
+import ApiError from '../ApiError';
+
+class UnexpectedEmptyResponseError extends ApiError {
+  constructor(message: string): void {
+    super(message);
+
+    // Temporary workaround for https://github.com/istanbuljs/babel-plugin-istanbul/issues/143 #TODO
+    /* eslint-disable no-proto */
+    // $FlowFixMe Temporary workaround
+    this.constructor = UnexpectedEmptyResponseError;
+    // $FlowFixMe Temporary workaround
+    this.__proto__ = UnexpectedEmptyResponseError.prototype;
+    /* eslint-enable */
+  }
+}
+
+export default UnexpectedEmptyResponseError;

--- a/app/errors/apiErrors/subclasses/UnexpectedEmptyResponseError.test.js
+++ b/app/errors/apiErrors/subclasses/UnexpectedEmptyResponseError.test.js
@@ -1,0 +1,20 @@
+// @flow
+
+import { UnexpectedEmptyResponseError } from '../..';
+
+describe(`UnexpectedEmptyResponseError`, (): void => {
+
+  it(`can be thrown and caught`, (): void => {
+    let error: typeof Error;
+    try {
+      // noinspection ExceptionCaughtLocallyJS
+      throw new UnexpectedEmptyResponseError('Test');
+    }
+    catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeInstanceOf(UnexpectedEmptyResponseError);
+  });
+
+});

--- a/app/errors/apiErrors/subclasses/UnexpectedEmptyResponseError.test.js
+++ b/app/errors/apiErrors/subclasses/UnexpectedEmptyResponseError.test.js
@@ -17,4 +17,18 @@ describe(`UnexpectedEmptyResponseError`, (): void => {
     expect(error).toBeInstanceOf(UnexpectedEmptyResponseError);
   });
 
+  it(`sets a default message, if no message is passed`, (): void => {
+    let error: typeof Error;
+    try {
+      // noinspection ExceptionCaughtLocallyJS
+      throw new UnexpectedEmptyResponseError();
+    }
+    catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeInstanceOf(UnexpectedEmptyResponseError);
+    expect((error: any).message).toBe(`Unexpected empty response data`);
+  });
+
 });

--- a/app/errors/apiErrors/subclasses/UnexpectedHttpResponseError.js
+++ b/app/errors/apiErrors/subclasses/UnexpectedHttpResponseError.js
@@ -6,7 +6,7 @@
 
 import ApiError from '../ApiError';
 
-class UnexpectedEmptyResponseError extends ApiError {
+class UnexpectedHttpResponseError extends ApiError {
   constructor(message: ?string = null): void {
     let newMessage: string;
 
@@ -22,11 +22,11 @@ class UnexpectedEmptyResponseError extends ApiError {
     // Temporary workaround for https://github.com/istanbuljs/babel-plugin-istanbul/issues/143 #TODO
     /* eslint-disable no-proto */
     // $FlowFixMe Temporary workaround
-    this.constructor = UnexpectedEmptyResponseError;
+    this.constructor = UnexpectedHttpResponseError;
     // $FlowFixMe Temporary workaround
-    this.__proto__ = UnexpectedEmptyResponseError.prototype;
+    this.__proto__ = UnexpectedHttpResponseError.prototype;
     /* eslint-enable */
   }
 }
 
-export default UnexpectedEmptyResponseError;
+export default UnexpectedHttpResponseError;

--- a/app/errors/apiErrors/subclasses/UnexpectedHttpResponseError.test.js
+++ b/app/errors/apiErrors/subclasses/UnexpectedHttpResponseError.test.js
@@ -1,33 +1,33 @@
 // @flow
 
-import { UnexpectedEmptyResponseError } from '../..';
+import { UnexpectedHttpResponseError } from '../..';
 
-describe(`UnexpectedEmptyResponseError`, (): void => {
+describe(`UnexpectedHttpResponseError`, (): void => {
 
   it(`can be thrown and caught`, (): void => {
     let error: typeof Error;
     try {
       // noinspection ExceptionCaughtLocallyJS
-      throw new UnexpectedEmptyResponseError('Test');
+      throw new UnexpectedHttpResponseError('Test');
     }
     catch (e) {
       error = e;
     }
 
-    expect(error).toBeInstanceOf(UnexpectedEmptyResponseError);
+    expect(error).toBeInstanceOf(UnexpectedHttpResponseError);
   });
 
   it(`sets a default message, if no message is passed`, (): void => {
     let error: typeof Error;
     try {
       // noinspection ExceptionCaughtLocallyJS
-      throw new UnexpectedEmptyResponseError();
+      throw new UnexpectedHttpResponseError();
     }
     catch (e) {
       error = e;
     }
 
-    expect(error).toBeInstanceOf(UnexpectedEmptyResponseError);
+    expect(error).toBeInstanceOf(UnexpectedHttpResponseError);
     expect((error: any).message).toBe(`Unexpected empty response data`);
   });
 

--- a/app/lib/ApiRequest/ApiRequest/fetchApiResponseData/index.js
+++ b/app/lib/ApiRequest/ApiRequest/fetchApiResponseData/index.js
@@ -18,7 +18,7 @@ const getDataFromResponse = async (response: Response): Promise<ApiResponseData>
   const responseText = await response.text();
   const responseBody = (responseText)
     ? JSON.parse(responseText)
-    : {};
+    : null;
 
   return {
     body: responseBody,

--- a/app/lib/ApiRequest/ApiRequest/fetchApiResponseData/index.js
+++ b/app/lib/ApiRequest/ApiRequest/fetchApiResponseData/index.js
@@ -15,9 +15,11 @@ const extractTokenFromAuthHeader = (authHeader: ?string): ?string => {
 };
 
 const getDataFromResponse = async (response: Response): Promise<ApiResponseData> => {
-  const responseBody = (response.body)
-    ? await response.json()
+  const responseText = await response.text();
+  const responseBody = (responseText)
+    ? JSON.parse(responseText)
     : {};
+
   return {
     body: responseBody,
     status: response.status,

--- a/app/lib/ApiRequest/ApiRequest/fetchApiResponseData/index.test.js
+++ b/app/lib/ApiRequest/ApiRequest/fetchApiResponseData/index.test.js
@@ -29,10 +29,22 @@ describe(`fetchApiResponseData`, (): void => {
       });
   });
 
+  it(`returns a ResponseData object with an empty body on empty response body`, async (): Promise<mixed> => {
+    fetch.mockResponseOnce('', { status: 204 });
+
+    await expect(fetchApiResponseData('', {}))
+      .resolves
+      .toEqual({
+        body: {},
+        status: 204,
+        token: null,
+      });
+  });
+
   it(`returns a ResponseData object with the correct token`, async (): Promise<mixed> => {
     const dummyToken = 'foobarToken';
     fetch.mockResponseOnce(
-      null,
+      '',
       { status: 200, headers: { Authorization: `Bearer ${dummyToken}` } },
     );
 
@@ -46,7 +58,7 @@ describe(`fetchApiResponseData`, (): void => {
   });
 
   it(`throws an Http401UnauthorizedError, when the response contains a 401 status code`, async (): Promise<mixed> => {
-    fetch.mockResponseOnce(null, { status: 401 });
+    fetch.mockResponseOnce('', { status: 401 });
 
     await expect(fetchApiResponseData('', {}))
       .rejects
@@ -54,7 +66,7 @@ describe(`fetchApiResponseData`, (): void => {
   });
 
   it(`throws an Http403ForbiddenError, when the response contains a 403 status code`, async (): Promise<mixed> => {
-    fetch.mockResponseOnce(null, { status: 403 });
+    fetch.mockResponseOnce('', { status: 403 });
 
     await expect(fetchApiResponseData('', {}))
       .rejects
@@ -72,7 +84,7 @@ describe(`fetchApiResponseData`, (): void => {
 
   it(`throws an Http5xxServerError, when the response contains a 5xx status code`, async (): Promise<mixed> => {
     const dummyErrorText = `Service unavailable`;
-    fetch.mockResponseOnce(null, { status: 503, statusText: dummyErrorText });
+    fetch.mockResponseOnce('', { status: 503, statusText: dummyErrorText });
 
     await expect(fetchApiResponseData('', {}))
       .rejects
@@ -81,7 +93,7 @@ describe(`fetchApiResponseData`, (): void => {
 
   it(`throws an UnexpectedHttpStatusError, when the response contains a status code that is not otherwise handled`, async (): Promise<mixed> => {
     const dummyErrorText = `I'm a teapot`;
-    fetch.mockResponseOnce(null, { status: 418, statusText: dummyErrorText });
+    fetch.mockResponseOnce('', { status: 418, statusText: dummyErrorText });
 
     await expect(fetchApiResponseData('', {}))
       .rejects

--- a/app/lib/ApiRequest/ApiRequest/fetchApiResponseData/index.test.js
+++ b/app/lib/ApiRequest/ApiRequest/fetchApiResponseData/index.test.js
@@ -35,7 +35,7 @@ describe(`fetchApiResponseData`, (): void => {
     await expect(fetchApiResponseData('', {}))
       .resolves
       .toEqual({
-        body: {},
+        body: null,
         status: 204,
         token: null,
       });
@@ -51,7 +51,7 @@ describe(`fetchApiResponseData`, (): void => {
     await expect(fetchApiResponseData('', {}))
       .resolves
       .toEqual({
-        body: {},
+        body: null,
         status: 200,
         token: dummyToken,
       });

--- a/app/lib/ApiRequest/types.js
+++ b/app/lib/ApiRequest/types.js
@@ -37,7 +37,7 @@ export type ApiRequestConfig = {|
 
 export type ApiResponseData = {|
   // eslint-disable-next-line flowtype/no-weak-types
-  +body: Object,
+  +body: ?Object,
   +status: number,
   +token: ?string,
 |};

--- a/app/modules/platform/saga/api/apiPostSigninToTokenAndGetUserAuth.js
+++ b/app/modules/platform/saga/api/apiPostSigninToTokenAndGetUserAuth.js
@@ -27,7 +27,7 @@ const apiPostSigninToTokenAndGetUserAuth = function* (
     // Get flow to stop complaining about token possibly being NULL
     if (responseData.token == null) throw new Error(`This shouldn't happen`);
 
-    if (responseData.body == null) throw new UnexpectedEmptyResponseError(`Unexpected empty response data`);
+    if (responseData.body == null) throw new UnexpectedEmptyResponseError();
 
     // Extract UserAuth data from response
     const { id, attributes } = responseData.body.data;

--- a/app/modules/platform/saga/api/apiPostSigninToTokenAndGetUserAuth.js
+++ b/app/modules/platform/saga/api/apiPostSigninToTokenAndGetUserAuth.js
@@ -5,6 +5,7 @@ import { call, put } from 'redux-saga/effects';
 import { flashErrorMessage } from 'redux-flash';
 
 import api from 'api';
+import { UnexpectedEmptyResponseError } from 'errors';
 import { type ApiResponseData } from 'lib/ApiRequest';
 import apiRequestsStatus from 'modules/apiRequestsStatus';
 import users from 'modules/users';
@@ -24,13 +25,14 @@ const apiPostSigninToTokenAndGetUserAuth = function* (
     const responseData: ApiResponseData = yield call(api.token.postSignin, email, password);
 
     // Get flow to stop complaining about token possibly being NULL
-    if (responseData.token == null) {
-      throw new Error(`This shouldn't happen`);
-    }
+    if (responseData.token == null) throw new Error(`This shouldn't happen`);
+
+    if (responseData.body == null) throw new UnexpectedEmptyResponseError(`Unexpected empty response data`);
 
     // Extract UserAuth data from response
+    const { id, attributes } = responseData.body.data;
     const currentUserAuth: m.UserAuth = {
-      userId: responseData.body.data.id,
+      userId: id,
       apiToken: responseData.token,
     };
 
@@ -38,9 +40,8 @@ const apiPostSigninToTokenAndGetUserAuth = function* (
     yield put(actions.setUserAuthInState(currentUserAuth));
 
     // Extract currentUser object from response
-    const { attributes } = responseData.body.data;
     const currentUser: users.model.User = {
-      id: responseData.body.data.id,
+      id,
       email,
       name: attributes.name,
       gravatarHash: attributes.gravatarHash,

--- a/app/modules/platform/saga/api/apiPostSigninToTokenAndGetUserAuth.js
+++ b/app/modules/platform/saga/api/apiPostSigninToTokenAndGetUserAuth.js
@@ -24,10 +24,9 @@ const apiPostSigninToTokenAndGetUserAuth = function* (
   try {
     const responseData: ApiResponseData = yield call(api.token.postSignin, email, password);
 
-    // Get flow to stop complaining about token possibly being NULL
-    if (responseData.token == null) throw new Error(`This shouldn't happen`);
-
-    if (responseData.body == null) throw new UnexpectedEmptyResponseError();
+    if (responseData.token == null || responseData.body == null) {
+      throw new UnexpectedEmptyResponseError();
+    }
 
     // Extract UserAuth data from response
     const { id, attributes } = responseData.body.data;

--- a/app/modules/platform/saga/api/apiPostSigninToTokenAndGetUserAuth.js
+++ b/app/modules/platform/saga/api/apiPostSigninToTokenAndGetUserAuth.js
@@ -5,7 +5,7 @@ import { call, put } from 'redux-saga/effects';
 import { flashErrorMessage } from 'redux-flash';
 
 import api from 'api';
-import { UnexpectedEmptyResponseError } from 'errors';
+import { UnexpectedHttpResponseError } from 'errors';
 import { type ApiResponseData } from 'lib/ApiRequest';
 import apiRequestsStatus from 'modules/apiRequestsStatus';
 import users from 'modules/users';
@@ -25,7 +25,7 @@ const apiPostSigninToTokenAndGetUserAuth = function* (
     const responseData: ApiResponseData = yield call(api.token.postSignin, email, password);
 
     if (responseData.token == null || responseData.body == null) {
-      throw new UnexpectedEmptyResponseError();
+      throw new UnexpectedHttpResponseError();
     }
 
     // Extract UserAuth data from response

--- a/app/modules/platform/saga/api/apiPostSigninToTokenAndGetUserAuth.test.js
+++ b/app/modules/platform/saga/api/apiPostSigninToTokenAndGetUserAuth.test.js
@@ -5,7 +5,7 @@ import { call } from 'redux-saga/effects';
 import { expectSaga } from 'redux-saga-test-plan';
 
 import api from 'api';
-import { UnexpectedEmptyResponseError } from 'errors';
+import { UnexpectedHttpResponseError } from 'errors';
 import apiRequestsStatus from 'modules/apiRequestsStatus';
 import users from 'modules/users';
 
@@ -118,7 +118,7 @@ describe(`apiPostSigninToTokenAndGetUserAuth`, (): void => {
       .provide([
         [call(api.token.postSignin, dummyEmail, dummyPassword), dummyApiResponse],
       ])
-      .put.actionType(apiRequestsStatus.actions.setFailure(a.API_POST_SIGNIN_TO_TOKEN_AND_GET_USER_AUTH, new UnexpectedEmptyResponseError()).type)
+      .put.actionType(apiRequestsStatus.actions.setFailure(a.API_POST_SIGNIN_TO_TOKEN_AND_GET_USER_AUTH, new UnexpectedHttpResponseError()).type)
       .run();
 
     expect(_.last(result.allEffects).PUT.action.payload.error).toBeInstanceOf(Error);
@@ -143,7 +143,7 @@ describe(`apiPostSigninToTokenAndGetUserAuth`, (): void => {
       .provide([
         [call(api.token.postSignin, dummyEmail, dummyPassword), dummyApiResponse],
       ])
-      .put.actionType(apiRequestsStatus.actions.setFailure(a.API_POST_SIGNIN_TO_TOKEN_AND_GET_USER_AUTH, new UnexpectedEmptyResponseError()).type)
+      .put.actionType(apiRequestsStatus.actions.setFailure(a.API_POST_SIGNIN_TO_TOKEN_AND_GET_USER_AUTH, new UnexpectedHttpResponseError()).type)
       .run();
 
     expect(_.last(result.allEffects).PUT.action.payload.error).toBeInstanceOf(Error);

--- a/app/modules/platform/saga/api/apiPostSigninToTokenAndGetUserAuth.test.js
+++ b/app/modules/platform/saga/api/apiPostSigninToTokenAndGetUserAuth.test.js
@@ -143,7 +143,7 @@ describe(`apiPostSigninToTokenAndGetUserAuth`, (): void => {
       .provide([
         [call(api.token.postSignin, dummyEmail, dummyPassword), dummyApiResponse],
       ])
-      .put.actionType(apiRequestsStatus.actions.setFailure(a.API_POST_SIGNIN_TO_TOKEN_AND_GET_USER_AUTH, new Error()).type)
+      .put.actionType(apiRequestsStatus.actions.setFailure(a.API_POST_SIGNIN_TO_TOKEN_AND_GET_USER_AUTH, new UnexpectedEmptyResponseError()).type)
       .run();
 
     expect(_.last(result.allEffects).PUT.action.payload.error).toBeInstanceOf(Error);

--- a/app/modules/platform/saga/api/apiPostSigninToTokenAndGetUserAuth.test.js
+++ b/app/modules/platform/saga/api/apiPostSigninToTokenAndGetUserAuth.test.js
@@ -5,6 +5,7 @@ import { call } from 'redux-saga/effects';
 import { expectSaga } from 'redux-saga-test-plan';
 
 import api from 'api';
+import { UnexpectedEmptyResponseError } from 'errors';
 import apiRequestsStatus from 'modules/apiRequestsStatus';
 import users from 'modules/users';
 
@@ -106,6 +107,24 @@ describe(`apiPostSigninToTokenAndGetUserAuth`, (): void => {
   });
 
   it(`sets its request status to FAILURE and passes on the correct error, when the api response does not contain a token`, async (): Promise<mixed> => {
+    const dummyAction = actions.apiPostSigninToTokenAndGetUserAuth(dummyEmail, dummyPassword);
+    const dummyApiResponse = {
+      body: null,
+      status: 201,
+      token: dummyToken,
+    };
+
+    const result = await expectSaga(sagas.apiPostSigninToTokenAndGetUserAuth, dummyAction)
+      .provide([
+        [call(api.token.postSignin, dummyEmail, dummyPassword), dummyApiResponse],
+      ])
+      .put.actionType(apiRequestsStatus.actions.setFailure(a.API_POST_SIGNIN_TO_TOKEN_AND_GET_USER_AUTH, new UnexpectedEmptyResponseError()).type)
+      .run();
+
+    expect(_.last(result.allEffects).PUT.action.payload.error).toBeInstanceOf(Error);
+  });
+
+  it(`sets its request status to FAILURE and passes on the correct error, when the api response does not contain a body`, async (): Promise<mixed> => {
     const dummyAction = actions.apiPostSigninToTokenAndGetUserAuth(dummyEmail, dummyPassword);
     const dummyApiResponse = {
       body: {

--- a/app/modules/users/saga/api/apiGet.js
+++ b/app/modules/users/saga/api/apiGet.js
@@ -4,7 +4,7 @@ import { type Saga } from 'redux-saga';
 import { call, put, select } from 'redux-saga/effects';
 
 import api from 'api';
-import { UnsupportedOperationError, UnexpectedEmptyResponseError } from 'errors';
+import { UnsupportedOperationError, UnexpectedHttpResponseError } from 'errors';
 import { type ApiResponseData } from 'lib/ApiRequest';
 import apiRequestsStatus from 'modules/apiRequestsStatus';
 import platform from 'modules/platform';
@@ -23,7 +23,7 @@ const apiGet = function* (action: a.ApiGetAction): Saga<void> {
 
     const responseData: ApiResponseData = yield call(api.users.get, id, userAuth.apiToken);
 
-    if (responseData.body == null) throw new UnexpectedEmptyResponseError();
+    if (responseData.body == null) throw new UnexpectedHttpResponseError();
 
     const { attributes } = responseData.body.data;
     const user: m.User = {

--- a/app/modules/users/saga/api/apiGet.js
+++ b/app/modules/users/saga/api/apiGet.js
@@ -4,7 +4,7 @@ import { type Saga } from 'redux-saga';
 import { call, put, select } from 'redux-saga/effects';
 
 import api from 'api';
-import { UnsupportedOperationError } from 'errors';
+import { UnsupportedOperationError, UnexpectedEmptyResponseError } from 'errors';
 import { type ApiResponseData } from 'lib/ApiRequest';
 import apiRequestsStatus from 'modules/apiRequestsStatus';
 import platform from 'modules/platform';
@@ -22,6 +22,9 @@ const apiGet = function* (action: a.ApiGetAction): Saga<void> {
     if (userAuth == null) throw new UnsupportedOperationError(`Not signed in.`);
 
     const responseData: ApiResponseData = yield call(api.users.get, id, userAuth.apiToken);
+
+    if (responseData.body == null) throw new UnexpectedEmptyResponseError(`Unexpected empty response data`);
+
     const { attributes } = responseData.body.data;
     const user: m.User = {
       id,

--- a/app/modules/users/saga/api/apiGet.js
+++ b/app/modules/users/saga/api/apiGet.js
@@ -23,7 +23,7 @@ const apiGet = function* (action: a.ApiGetAction): Saga<void> {
 
     const responseData: ApiResponseData = yield call(api.users.get, id, userAuth.apiToken);
 
-    if (responseData.body == null) throw new UnexpectedEmptyResponseError(`Unexpected empty response data`);
+    if (responseData.body == null) throw new UnexpectedEmptyResponseError();
 
     const { attributes } = responseData.body.data;
     const user: m.User = {

--- a/app/modules/users/saga/api/apiGet.js
+++ b/app/modules/users/saga/api/apiGet.js
@@ -4,7 +4,7 @@ import { type Saga } from 'redux-saga';
 import { call, put, select } from 'redux-saga/effects';
 
 import api from 'api';
-import { UnsupportedOperationError, UnexpectedHttpResponseError } from 'errors';
+import { UnexpectedHttpResponseError } from 'errors';
 import { type ApiResponseData } from 'lib/ApiRequest';
 import apiRequestsStatus from 'modules/apiRequestsStatus';
 import platform from 'modules/platform';
@@ -19,9 +19,9 @@ const apiGet = function* (action: a.ApiGetAction): Saga<void> {
   try {
     const { id } = action.payload;
     const userAuth: ?platform.model.UserAuth = yield select(platform.selectors.getUserAuth);
-    if (userAuth == null) throw new UnsupportedOperationError(`Not signed in.`);
+    const token: ?string = (userAuth == null ? null : userAuth.apiToken);
 
-    const responseData: ApiResponseData = yield call(api.users.get, id, userAuth.apiToken);
+    const responseData: ApiResponseData = yield call(api.users.get, id, token);
 
     if (responseData.body == null) throw new UnexpectedHttpResponseError();
 

--- a/app/modules/users/saga/api/apiGet.test.js
+++ b/app/modules/users/saga/api/apiGet.test.js
@@ -5,7 +5,7 @@ import { call, select } from 'redux-saga/effects';
 import { expectSaga } from 'redux-saga-test-plan';
 
 import api from 'api';
-import { UnsupportedOperationError } from 'errors';
+import { UnsupportedOperationError, UnexpectedEmptyResponseError } from 'errors';
 import apiRequestsStatus from 'modules/apiRequestsStatus';
 import platform from 'modules/platform';
 
@@ -125,6 +125,25 @@ describe(`apiGet`, (): void => {
       ])
       .put(apiRequestsStatus.actions.setPending(a.API_GET))
       .put.actionType(apiRequestsStatus.actions.setFailure(a.API_GET, new Error()).type)
+      .run();
+
+    expect(_.last(result.allEffects).PUT.action.payload.error).toBeInstanceOf(UnsupportedOperationError);
+  });
+
+  it(`sets its request status to FAILURE, when the api response does not contain a body`, async (): Promise<mixed> => {
+    const dummyAction = actions.apiGet(dummyId);
+    const dummyApiResponse = {
+      status: 200,
+      body: null,
+    };
+
+    const result = await expectSaga(sagas.apiGet, dummyAction)
+      .provide([
+        [select(platform.selectors.getUserAuth), null],
+        [call(api.users.get, dummyId, dummyToken), dummyApiResponse],
+      ])
+      .put(apiRequestsStatus.actions.setPending(a.API_GET))
+      .put.actionType(apiRequestsStatus.actions.setFailure(a.API_GET, new UnexpectedEmptyResponseError()).type)
       .run();
 
     expect(_.last(result.allEffects).PUT.action.payload.error).toBeInstanceOf(UnsupportedOperationError);

--- a/app/modules/users/saga/api/apiGet.test.js
+++ b/app/modules/users/saga/api/apiGet.test.js
@@ -5,7 +5,7 @@ import { call, select } from 'redux-saga/effects';
 import { expectSaga } from 'redux-saga-test-plan';
 
 import api from 'api';
-import { UnsupportedOperationError, UnexpectedEmptyResponseError } from 'errors';
+import { UnsupportedOperationError, UnexpectedHttpResponseError } from 'errors';
 import apiRequestsStatus from 'modules/apiRequestsStatus';
 import platform from 'modules/platform';
 
@@ -143,7 +143,7 @@ describe(`apiGet`, (): void => {
         [call(api.users.get, dummyId, dummyToken), dummyApiResponse],
       ])
       .put(apiRequestsStatus.actions.setPending(a.API_GET))
-      .put.actionType(apiRequestsStatus.actions.setFailure(a.API_GET, new UnexpectedEmptyResponseError()).type)
+      .put.actionType(apiRequestsStatus.actions.setFailure(a.API_GET, new UnexpectedHttpResponseError()).type)
       .run();
 
     expect(_.last(result.allEffects).PUT.action.payload.error).toBeInstanceOf(UnsupportedOperationError);


### PR DESCRIPTION
Fixed the `SyntaxError: Unexpected end of JSON input` error on requests that return no response body. This was caused by not adequately checking if there is a proper body before trying to parse it to JSON.

The `mockResponseOnce` call everywhere was also changed not to use `null` as response body. In real conditions, `response.json()` or `response.text()` will always return something (a promise). Tests should mimic this behaviour by returning something (an empty string) instead of `null`.