### PR TITLE
Enable Single Sign On

### DIFF
--- a/app/components/ApplicationPage/AuthPage/SSOCallbackPage/index.js
+++ b/app/components/ApplicationPage/AuthPage/SSOCallbackPage/index.js
@@ -32,6 +32,11 @@ const mapDispatchToProps = (dispatch: Dispatch<Action>): DispatchProps => {
   };
 };
 
+/**
+ * SSO Callback Page - After the user successfully authenticates with an external provider,
+ * the user is redirected to this page given an API token and a user ID - signalling that
+ * the user should now be successfully signed in in the frontend.
+ */
 class PureSSOCallbackPage extends React.Component<Props> {
   componentDidMount(): void {
     const { location, signinSSO, flashErrorAndRedirect } = this.props;

--- a/app/components/ApplicationPage/AuthPage/SSOCallbackPage/index.js
+++ b/app/components/ApplicationPage/AuthPage/SSOCallbackPage/index.js
@@ -1,0 +1,48 @@
+// @flow
+
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { type Dispatch } from 'redux';
+import { translate, type TranslatorProps } from 'react-i18next';
+import { type ContextRouter as RouterProps } from 'react-router-dom';
+
+import { type Action } from 'types/action';
+import { InvalidArgumentError } from 'errors';
+import platform from 'modules/platform';
+
+type DispatchProps = {|
+  signinSSO: (token: string, id: string) => void,
+|};
+
+type Props = {| ...TranslatorProps, ...RouterProps, ...DispatchProps |};
+
+const mapDispatchToProps = (dispatch: Dispatch<Action>): DispatchProps => {
+  return {
+    signinSSO: (token: string, id: string): void => {
+      dispatch(platform.actions.signinSSO(token, id));
+    },
+  };
+};
+
+class PureSSOCallbackPage extends React.Component<Props> {
+  componentDidMount(): void {
+    const { location, signinSSO } = this.props;
+    const params = new URLSearchParams(location.search);
+    const apiToken = params.get('apiToken');
+    const userId = params.get('userId');
+
+    if (!apiToken) throw new InvalidArgumentError(`Invalid token`);
+    if (!userId) throw new InvalidArgumentError(`Invalid id`);
+
+    signinSSO(apiToken, userId);
+  }
+
+  render(): React.Node {
+    return null; // TODO: use ApiDimmer for GET /user?
+  }
+}
+
+const SSOCallbackPage = translate()(connect(null, mapDispatchToProps)(PureSSOCallbackPage));
+
+export { PureSSOCallbackPage };
+export default SSOCallbackPage;

--- a/app/components/ApplicationPage/AuthPage/SSOCallbackPage/index.js
+++ b/app/components/ApplicationPage/AuthPage/SSOCallbackPage/index.js
@@ -3,15 +3,19 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { type Dispatch } from 'redux';
+import { flashErrorMessage } from 'redux-flash';
 import { translate, type TranslatorProps } from 'react-i18next';
 import { type ContextRouter as RouterProps } from 'react-router-dom';
+import { push } from 'connected-react-router';
 
 import { type Action } from 'types/action';
 import { InvalidArgumentError } from 'errors';
 import platform from 'modules/platform';
+import * as paths from 'config/routes';
 
 type DispatchProps = {|
   signinSSO: (token: string, id: string) => void,
+  flashErrorAndRedirect: (error: string) => void,
 |};
 
 type Props = {| ...TranslatorProps, ...RouterProps, ...DispatchProps |};
@@ -21,15 +25,26 @@ const mapDispatchToProps = (dispatch: Dispatch<Action>): DispatchProps => {
     signinSSO: (token: string, id: string): void => {
       dispatch(platform.actions.signinSSO(token, id));
     },
+    flashErrorAndRedirect: (error: string): void => {
+      dispatch(flashErrorMessage(error));
+      dispatch(push(paths.AUTH_SIGNIN_ROUTE));
+    },
   };
 };
 
 class PureSSOCallbackPage extends React.Component<Props> {
   componentDidMount(): void {
-    const { location, signinSSO } = this.props;
+    const { location, signinSSO, flashErrorAndRedirect } = this.props;
     const params = new URLSearchParams(location.search);
+
+    const error = params.get('error');
     const apiToken = params.get('apiToken');
     const userId = params.get('userId');
+
+    if (error) {
+      flashErrorAndRedirect(error);
+      return;
+    }
 
     if (!apiToken) throw new InvalidArgumentError(`Invalid token`);
     if (!userId) throw new InvalidArgumentError(`Invalid id`);

--- a/app/components/ApplicationPage/AuthPage/SSOCallbackPage/index.test.js
+++ b/app/components/ApplicationPage/AuthPage/SSOCallbackPage/index.test.js
@@ -1,11 +1,14 @@
 // @flow
 
 import * as React from 'react';
+import { flashErrorMessage } from 'redux-flash';
 import { shallow, mount } from 'enzyme';
+import { push } from 'connected-react-router';
 
 import { DummyProviders, dummyProviderProps } from 'lib/testResources';
 import { InvalidArgumentError } from 'errors';
 import platform from 'modules/platform';
+import * as paths from 'config/routes';
 
 import SSOCallbackPage, { PureSSOCallbackPage } from '.';
 
@@ -70,6 +73,25 @@ describe(`SSOCallbackPage`, (): void => {
     );
 
     expect(dummyDispatch).toHaveBeenCalledWith(platform.actions.signinSSO(dummyApiToken, dummyId));
+  });
+
+  it(`sets a flash message and redirects to signin page when an error URL param is passed`, (): void => {
+    const fixedDummyRouterProps = {
+      ...dummyProviderProps.routerProps,
+      location: {
+        ...dummyProviderProps.routerProps.location,
+        search: `?error=MyCustomErrorMessage`,
+      },
+    };
+
+    mount(
+      <DummyProviders dummyState={dummyState} dummyDispatch={dummyDispatch}>
+        <SSOCallbackPage {...fixedDummyRouterProps} />
+      </DummyProviders>,
+    );
+
+    expect(dummyDispatch).toHaveBeenCalledWith(flashErrorMessage('MyCustomErrorMessage'));
+    expect(dummyDispatch).toHaveBeenCalledWith(push(paths.AUTH_SIGNIN_ROUTE));
   });
 
   it(`throws an InvalidArgumentError, when no apiToken is passed`, (): void => {

--- a/app/components/ApplicationPage/AuthPage/SSOCallbackPage/index.test.js
+++ b/app/components/ApplicationPage/AuthPage/SSOCallbackPage/index.test.js
@@ -95,23 +95,39 @@ describe(`SSOCallbackPage`, (): void => {
   });
 
   it(`throws an InvalidArgumentError, when no apiToken is passed`, (): void => {
+    const noApiTokenDummyRouterProps = {
+      ...dummyProviderProps.routerProps,
+      location: {
+        ...dummyProviderProps.routerProps.location,
+        search: `?userId=foobarId`,
+      },
+    };
+
     expect((): void => {
       shallow(
         <PureSSOCallbackPage
           {...dummyProviderProps.translatorProps}
-          {...dummyProviderProps.routerProps}
+          {...noApiTokenDummyRouterProps}
           signinSSO={dummySigninSSO}
         />,
       );
     }).toThrow(InvalidArgumentError);
   });
 
-  it(`throws an InvalidArgumentError, when no id is passed`, (): void => {
+  it(`throws an InvalidArgumentError, when no userId is passed`, (): void => {
+    const noUserIdDummyRouterProps = {
+      ...dummyProviderProps.routerProps,
+      location: {
+        ...dummyProviderProps.routerProps.location,
+        search: `?apiToken=foobarToken`,
+      },
+    };
+
     expect((): void => {
       shallow(
         <PureSSOCallbackPage
           {...dummyProviderProps.translatorProps}
-          {...dummyProviderProps.routerProps}
+          {...noUserIdDummyRouterProps}
           signinSSO={dummySigninSSO}
         />,
       );

--- a/app/components/ApplicationPage/AuthPage/SSOCallbackPage/index.test.js
+++ b/app/components/ApplicationPage/AuthPage/SSOCallbackPage/index.test.js
@@ -1,0 +1,99 @@
+// @flow
+
+import * as React from 'react';
+import { shallow, mount } from 'enzyme';
+
+import { DummyProviders, dummyProviderProps } from 'lib/testResources';
+import { InvalidArgumentError } from 'errors';
+import platform from 'modules/platform';
+
+import SSOCallbackPage, { PureSSOCallbackPage } from '.';
+
+describe(`SSOCallbackPage`, (): void => {
+
+  let dummyApiToken: string;
+  let dummyId: any;
+  let dummySigninSSO: any;
+
+  let dummyDispatch: any;
+  let dummyState: any;
+
+  beforeEach((): void => {
+    dummyApiToken = 'foobarApiToken';
+    dummyId = 'foobarId';
+    dummySigninSSO = jest.fn();
+
+    dummyDispatch = jest.fn();
+    dummyState = {
+      modules: {
+        apiRequestsStatus: {},
+        platform: { userAuth: null },
+      },
+      flash: {
+        messages: [],
+      },
+    };
+  });
+
+  it(`renders without errors`, (): void => {
+    const fixedDummyRouterProps = {
+      ...dummyProviderProps.routerProps,
+      location: {
+        ...dummyProviderProps.routerProps.location,
+        search: `?apiToken=${dummyApiToken}&userId=${dummyId}`,
+      },
+    };
+
+    const enzymeWrapper = shallow(
+      <PureSSOCallbackPage
+        {...dummyProviderProps.translatorProps}
+        {...fixedDummyRouterProps}
+        signinSSO={dummySigninSSO}
+      />,
+    );
+    expect(enzymeWrapper.isEmptyRender()).toEqual(true);
+  });
+
+  it(`dispatches a signinSSO() action with the passed apiToken and id`, (): void => {
+    const fixedDummyRouterProps = {
+      ...dummyProviderProps.routerProps,
+      location: {
+        ...dummyProviderProps.routerProps.location,
+        search: `?apiToken=${dummyApiToken}&userId=${dummyId}`,
+      },
+    };
+
+    mount(
+      <DummyProviders dummyState={dummyState} dummyDispatch={dummyDispatch}>
+        <SSOCallbackPage {...fixedDummyRouterProps} />
+      </DummyProviders>,
+    );
+
+    expect(dummyDispatch).toHaveBeenCalledWith(platform.actions.signinSSO(dummyApiToken, dummyId));
+  });
+
+  it(`throws an InvalidArgumentError, when no apiToken is passed`, (): void => {
+    expect((): void => {
+      shallow(
+        <PureSSOCallbackPage
+          {...dummyProviderProps.translatorProps}
+          {...dummyProviderProps.routerProps}
+          signinSSO={dummySigninSSO}
+        />,
+      );
+    }).toThrow(InvalidArgumentError);
+  });
+
+  it(`throws an InvalidArgumentError, when no id is passed`, (): void => {
+    expect((): void => {
+      shallow(
+        <PureSSOCallbackPage
+          {...dummyProviderProps.translatorProps}
+          {...dummyProviderProps.routerProps}
+          signinSSO={dummySigninSSO}
+        />,
+      );
+    }).toThrow(InvalidArgumentError);
+  });
+
+});

--- a/app/components/ApplicationPage/AuthPage/index.js
+++ b/app/components/ApplicationPage/AuthPage/index.js
@@ -16,6 +16,7 @@ import ResendConfirmationEmailPage from './ResendConfirmationEmailPage';
 import SendResetPasswordEmailPage from './SendResetPasswordEmailPage';
 import SigninPage from './SigninPage';
 import SignupPage from './SignupPage';
+import SSOCallbackPage from './SSOCallbackPage';
 
 type Props = {| |};
 
@@ -31,6 +32,7 @@ const PureAuthPage = (props: Props): React.Node => {
         <Route path={paths.AUTH_RESET_PASSWORD_ROUTE} component={ResetPasswordPage} />
         <Route path={paths.AUTH_RESEND_CONFIRMATION_EMAIL_ROUTE} component={ResendConfirmationEmailPage} />
         <Route path={paths.AUTH_SEND_RESET_PASSWORD_EMAIL_ROUTE} component={SendResetPasswordEmailPage} />
+        <Route path={paths.AUTH_SSO_CALLBACK} component={SSOCallbackPage} />
         <Route component={NotFoundPage} />
       </Switch>
     </UnauthWrapper>

--- a/app/config/routes.js
+++ b/app/config/routes.js
@@ -21,6 +21,7 @@ export const AUTH_SEND_RESET_PASSWORD_EMAIL_ROUTE = '/auth/reset';
 export const AUTH_SSO_CALLBACK = '/auth/sso';
 export const AUTH_SSO_GOOGLE = '/oauth/google_oauth2';
 export const AUTH_SSO_FACEBOOK = '/oauth/facebook';
+export const AUTH_SSO_UGENT = '/oauth/cas';
 // DEV
 export const DEV_ROUTE = '/dev';
 export const DEV_GENERATE_RANDOM_STRING_ROUTE = '/dev/generaterandomstring';

--- a/app/config/routes.js
+++ b/app/config/routes.js
@@ -18,6 +18,7 @@ export const AUTH_CONFIRM_EMAIL_ROUTE = '/auth/confirmation';
 export const AUTH_RESET_PASSWORD_ROUTE = '/auth/password';
 export const AUTH_RESEND_CONFIRMATION_EMAIL_ROUTE = '/auth/resend';
 export const AUTH_SEND_RESET_PASSWORD_EMAIL_ROUTE = '/auth/reset';
+// SSO AUTH
 export const AUTH_SSO_CALLBACK = '/auth/sso';
 export const AUTH_SSO_GOOGLE = '/oauth/google_oauth2';
 export const AUTH_SSO_FACEBOOK = '/oauth/facebook';

--- a/app/config/routes.js
+++ b/app/config/routes.js
@@ -18,6 +18,7 @@ export const AUTH_CONFIRM_EMAIL_ROUTE = '/auth/confirmation';
 export const AUTH_RESET_PASSWORD_ROUTE = '/auth/password';
 export const AUTH_RESEND_CONFIRMATION_EMAIL_ROUTE = '/auth/resend';
 export const AUTH_SEND_RESET_PASSWORD_EMAIL_ROUTE = '/auth/reset';
+export const AUTH_SSO_CALLBACK = '/auth/sso';
 export const AUTH_SSO_GOOGLE = '/oauth/google_oauth2';
 export const AUTH_SSO_FACEBOOK = '/oauth/facebook';
 // DEV

--- a/app/config/routes.js
+++ b/app/config/routes.js
@@ -18,6 +18,8 @@ export const AUTH_CONFIRM_EMAIL_ROUTE = '/auth/confirmation';
 export const AUTH_RESET_PASSWORD_ROUTE = '/auth/password';
 export const AUTH_RESEND_CONFIRMATION_EMAIL_ROUTE = '/auth/resend';
 export const AUTH_SEND_RESET_PASSWORD_EMAIL_ROUTE = '/auth/reset';
+export const AUTH_SSO_GOOGLE = '/oauth/google_oauth2';
+export const AUTH_SSO_FACEBOOK = '/oauth/facebook';
 // DEV
 export const DEV_ROUTE = '/dev';
 export const DEV_GENERATE_RANDOM_STRING_ROUTE = '/dev/generaterandomstring';

--- a/app/i18n/en/platform.js
+++ b/app/i18n/en/platform.js
@@ -11,6 +11,7 @@ const platform = {
       signup: 'Sign up',
       forgotPassword: 'Forgot password?',
       resendConfirmationEmail: 'Resend confirmation email',
+      signinWithProvider: 'Sign in with {{provider}}',
     },
     // request: {
     //   pending: 'Signing in...',

--- a/app/modules/platform/actionTypes/taskSaga.js
+++ b/app/modules/platform/actionTypes/taskSaga.js
@@ -9,6 +9,7 @@ import * as m from '../model';
 
 // Authentication
 export const SIGNIN: 'platform/SIGNIN' = 'platform/SIGNIN';
+export const SIGNIN_SSO: 'platform/SIGNIN_SSO' = 'platform/SIGNIN_SSO';
 export const SIGNOUT: 'platform/SIGNOUT' = 'platform/SIGNOUT';
 export const SIGNUP: 'platform/SIGNUP' = 'platform/SIGNUP';
 export const CONFIRM_EMAIL: 'platform/CONFIRM_EMAIL' = 'platform/CONFIRM_EMAIL';
@@ -26,6 +27,14 @@ export type SigninAction = {|
   payload: {
     email: string,
     password: string,
+  },
+|};
+
+export type SigninSSOAction = {|
+  type: typeof SIGNIN_SSO,
+  payload: {
+    apiToken: string,
+    userId: string,
   },
 |};
 
@@ -84,6 +93,7 @@ export type ToggleSidebarAction = {|
 
 export type TaskSagaAction =
   | SigninAction
+  | SigninSSOAction
   | SignoutAction
   | SignupAction
   | ConfirmEmailAction

--- a/app/modules/platform/actions/taskSaga/index.js
+++ b/app/modules/platform/actions/taskSaga/index.js
@@ -5,6 +5,7 @@ import resendConfirmationEmail from './resendConfirmationEmail';
 import resetPassword from './resetPassword';
 import sendResetPasswordEmail from './sendResetPasswordEmail';
 import signin from './signin';
+import signinSSO from './signinSSO';
 import signout from './signout';
 import signup from './signup';
 import toggleSidebar from './toggleSidebar';
@@ -15,6 +16,7 @@ const taskSagaActions = {
   resetPassword,
   sendResetPasswordEmail,
   signin,
+  signinSSO,
   signout,
   signup,
   toggleSidebar,

--- a/app/modules/platform/actions/taskSaga/signinSSO.js
+++ b/app/modules/platform/actions/taskSaga/signinSSO.js
@@ -1,0 +1,15 @@
+// @flow
+
+import * as a from '../../actionTypes';
+
+const signinSSO = (apiToken: string, userId: string): a.SigninSSOAction => {
+  return {
+    type: a.SIGNIN_SSO,
+    payload: {
+      apiToken,
+      userId,
+    },
+  };
+};
+
+export default signinSSO;

--- a/app/modules/platform/actions/taskSaga/signinSSO.test.js
+++ b/app/modules/platform/actions/taskSaga/signinSSO.test.js
@@ -1,0 +1,23 @@
+// @flow
+
+import * as a from '../../actionTypes';
+
+import actions from '.';
+
+describe(`signinSSO`, (): void => {
+
+  it(`returns a platform signinSSO action containing the passed props`, (): void => {
+    const dummyApiToken = 'foobarToken';
+    const dummyUserId = 'foobarId';
+    const expectedAction: a.SigninSSOAction = {
+      type: a.SIGNIN_SSO,
+      payload: {
+        apiToken: dummyApiToken,
+        userId: dummyUserId,
+      },
+    };
+    const actualAction = actions.signinSSO(dummyApiToken, dummyUserId);
+    expect(actualAction).toEqual(expectedAction);
+  });
+
+});

--- a/app/modules/platform/components/SigninCard/index.js
+++ b/app/modules/platform/components/SigninCard/index.js
@@ -14,6 +14,7 @@ import {
   AUTH_RESEND_CONFIRMATION_EMAIL_ROUTE,
   AUTH_SSO_GOOGLE,
   AUTH_SSO_FACEBOOK,
+  AUTH_SSO_UGENT,
 } from 'config/routes';
 import { InvalidArgumentError } from 'errors';
 import EmailAndPasswordForm, { type EmailAndPasswordFormValues } from 'forms/EmailAndPasswordForm';
@@ -83,11 +84,14 @@ const PureSigninCard = (props: Props): React.Node => {
       </Card.Content>
       <Card.Content>
         <Button.Group fluid={true} vertical={true} basic={true}>
-          <Button as={Link} to={AUTH_SSO_GOOGLE}>
+          <Button as="a" href={AUTH_SSO_GOOGLE}>
             {t('platform:signinCard.link.signinWithProvider', { provider: 'Google' })}
           </Button>
-          <Button as={Link} to={AUTH_SSO_FACEBOOK}>
+          <Button as="a" href={AUTH_SSO_FACEBOOK}>
             {t('platform:signinCard.link.signinWithProvider', { provider: 'Facebook' })}
+          </Button>
+          <Button as="a" href={AUTH_SSO_UGENT}>
+            {t('platform:signinCard.link.signinWithProvider', { provider: 'UGent CAS' })}
           </Button>
         </Button.Group>
       </Card.Content>

--- a/app/modules/platform/components/SigninCard/index.js
+++ b/app/modules/platform/components/SigninCard/index.js
@@ -9,7 +9,11 @@ import { Card, Button, Icon } from 'semantic-ui-react';
 
 import { type Action } from 'types/action';
 import {
-  AUTH_SIGNUP_ROUTE, AUTH_SEND_RESET_PASSWORD_EMAIL_ROUTE, AUTH_RESEND_CONFIRMATION_EMAIL_ROUTE,
+  AUTH_SIGNUP_ROUTE,
+  AUTH_SEND_RESET_PASSWORD_EMAIL_ROUTE,
+  AUTH_RESEND_CONFIRMATION_EMAIL_ROUTE,
+  AUTH_SSO_GOOGLE,
+  AUTH_SSO_FACEBOOK,
 } from 'config/routes';
 import { InvalidArgumentError } from 'errors';
 import EmailAndPasswordForm, { type EmailAndPasswordFormValues } from 'forms/EmailAndPasswordForm';
@@ -74,6 +78,16 @@ const PureSigninCard = (props: Props): React.Node => {
           </Button>
           <Button as={Link} to={AUTH_RESEND_CONFIRMATION_EMAIL_ROUTE}>
             {t('platform:signinCard.link.resendConfirmationEmail')}
+          </Button>
+        </Button.Group>
+      </Card.Content>
+      <Card.Content>
+        <Button.Group fluid={true} vertical={true} basic={true}>
+          <Button as={Link} to={AUTH_SSO_GOOGLE}>
+            {t('platform:signinCard.link.signinWithProvider', { provider: 'Google' })}
+          </Button>
+          <Button as={Link} to={AUTH_SSO_FACEBOOK}>
+            {t('platform:signinCard.link.signinWithProvider', { provider: 'Facebook' })}
           </Button>
         </Button.Group>
       </Card.Content>

--- a/app/modules/platform/saga/task/index.js
+++ b/app/modules/platform/saga/task/index.js
@@ -12,6 +12,7 @@ import resendConfirmationEmail from './resendConfirmationEmail';
 import resetPassword from './resetPassword';
 import sendResetPasswordEmail from './sendResetPasswordEmail';
 import signin from './signin';
+import signinSSO from './signinSSO';
 import signout from './signout';
 import signup from './signup';
 import toggleSidebar from './toggleSidebar';
@@ -23,6 +24,7 @@ const taskSaga = function* (): Saga<void> {
     takeEvery(a.RESET_PASSWORD, resetPassword),
     takeEvery(a.SEND_RESET_PASSWORD_EMAIL, sendResetPasswordEmail),
     takeEvery(a.SIGNIN, signin),
+    takeEvery(a.SIGNIN_SSO, signinSSO),
     takeEvery(a.SIGNOUT, signout),
     takeEvery(a.SIGNUP, signup),
     takeEvery(a.TOGGLE_SIDEBAR, toggleSidebar),
@@ -35,6 +37,7 @@ const taskSagas = {
   resetPassword,
   sendResetPasswordEmail,
   signin,
+  signinSSO,
   signout,
   signup,
   toggleSidebar,

--- a/app/modules/platform/saga/task/signinSSO.js
+++ b/app/modules/platform/saga/task/signinSSO.js
@@ -3,17 +3,12 @@
 import { type Saga } from 'redux-saga';
 import { put } from 'redux-saga/effects';
 
-import users from 'modules/users';
-
 import actions from '../../actions';
 import * as a from '../../actionTypes';
 import * as m from '../../model';
 
 const signinSSO = function* (action: a.SigninSSOAction): Saga<void> {
   const { apiToken, userId } = action.payload;
-
-  // Dispatch action to retrieve the current user
-  yield put(users.actions.fetch(userId));
 
   // Dispatch action to set authenticated state
   const currentUserAuth: m.UserAuth = {

--- a/app/modules/platform/saga/task/signinSSO.js
+++ b/app/modules/platform/saga/task/signinSSO.js
@@ -1,0 +1,26 @@
+// @flow
+
+import { type Saga } from 'redux-saga';
+import { put } from 'redux-saga/effects';
+
+import users from 'modules/users';
+
+import actions from '../../actions';
+import * as a from '../../actionTypes';
+import * as m from '../../model';
+
+const signinSSO = function* (action: a.SigninSSOAction): Saga<void> {
+  const { apiToken, userId } = action.payload;
+
+  // Dispatch action to retrieve the current user
+  yield put(users.actions.fetch(userId));
+
+  // Dispatch action to set authenticated state
+  const currentUserAuth: m.UserAuth = {
+    apiToken,
+    userId,
+  };
+  yield put(actions.setUserAuthInState(currentUserAuth));
+};
+
+export default signinSSO;

--- a/app/modules/platform/saga/task/signinSSO.test.js
+++ b/app/modules/platform/saga/task/signinSSO.test.js
@@ -1,0 +1,30 @@
+// @flow
+
+import { expectSaga } from 'redux-saga-test-plan';
+
+import users from 'modules/users';
+
+import actions from '../../actions';
+
+import { sagas } from '..';
+
+describe(`signinSSO`, (): void => {
+
+  let dummyApiToken: string;
+  let dummyUserId: string;
+
+  beforeEach((): void => {
+    dummyApiToken = 'foobarToken';
+    dummyUserId = 'foobarUserId';
+  });
+
+  it(`puts a fetch and a setUserAuthInState action`, (): void => {
+    const dummyAction = actions.signinSSO(dummyApiToken, dummyUserId);
+
+    return expectSaga(sagas.signinSSO, dummyAction)
+      .put(users.actions.fetch(dummyUserId))
+      .put(actions.setUserAuthInState({ apiToken: dummyApiToken, userId: dummyUserId }))
+      .run();
+  });
+
+});

--- a/app/modules/platform/saga/task/signinSSO.test.js
+++ b/app/modules/platform/saga/task/signinSSO.test.js
@@ -2,8 +2,6 @@
 
 import { expectSaga } from 'redux-saga-test-plan';
 
-import users from 'modules/users';
-
 import actions from '../../actions';
 
 import { sagas } from '..';
@@ -22,7 +20,6 @@ describe(`signinSSO`, (): void => {
     const dummyAction = actions.signinSSO(dummyApiToken, dummyUserId);
 
     return expectSaga(sagas.signinSSO, dummyAction)
-      .put(users.actions.fetch(dummyUserId))
       .put(actions.setUserAuthInState({ apiToken: dummyApiToken, userId: dummyUserId }))
       .run();
   });


### PR DESCRIPTION
Enable SSO (Single Sign On) for the platform, using three providers:
- Google
- Facebook
- UGent CAS

Users can use these providers to sign in to the platform without having to sign up. Caveat: the user is identified by its email, so signing in with a UGent CAS account will necessarily use a UGent email address.

This PR adds links to the sign in page, and a callback page that processes the server response.

@Dromin The sign in links will not work locally, because they redirect to `/oauth/whatever`, which is routed by the web server in production. http://owsdev.ugent.be has a working instance.