### PR TITLE
Rename notifications to feed

### DIFF
--- a/app/api/endpoints.js
+++ b/app/api/endpoints.js
@@ -4,6 +4,6 @@ export const TOKEN_ENDPOINT = '/token';
 export const USERS_ENDPOINT = '/users';
 export const PASSWORD_ENDPOINT = '/password';
 export const CONFIRMATION_ENDPOINT = '/confirmation';
-export const NOTIFICATIONS_ENDPOINT = '/notifications';
+export const FEED_ITEMS_ENDPOINT = '/feedItems';
 export const TOPICS_ENDPOINT = '/topics';
 export const TOPICS_CONTENT_ENDPOINT = '/content';

--- a/app/api/feedItems/getAll.js
+++ b/app/api/feedItems/getAll.js
@@ -1,18 +1,18 @@
 // @flow
 
 /**
- * GET on notifications endpoint, get all notifications (events) for the recent activity feed
+ * GET on feedItems endpoint, get all Recent Activity feed items
  *
- * API documentation: https://openwebslides.github.io/documentation/#get-all-notifications
+ * API documentation: https://openwebslides.github.io/documentation/#get-all-feed-items
  */
 
 import ApiRequest, { httpMethods, type ApiResponseData } from 'lib/ApiRequest';
 
-import { NOTIFICATIONS_ENDPOINT } from '../endpoints';
+import { FEED_ITEMS_ENDPOINT } from '../endpoints';
 
 const getAll = (): Promise<ApiResponseData> => {
   return new ApiRequest(httpMethods.GET)
-    .addPathSegment(NOTIFICATIONS_ENDPOINT)
+    .addPathSegment(FEED_ITEMS_ENDPOINT)
     .setParameter('sort', '-createdAt')
     .setParameter('page[limit]', '10')
     .setParameter('page[offset]', '0')

--- a/app/api/feedItems/getAll.test.js
+++ b/app/api/feedItems/getAll.test.js
@@ -5,7 +5,7 @@ import { httpMethods } from 'lib/ApiRequest';
 
 import api from '..';
 
-describe(`api.notifications.getAll`, (): void => {
+describe(`api.feedItems.getAll`, (): void => {
 
   beforeEach((): void => {
     fetch.resetMocks();
@@ -13,14 +13,14 @@ describe(`api.notifications.getAll`, (): void => {
 
   it(`executes the correct fetch call`, async (): Promise<mixed> => {
     fetch.mockResponseOnce('', { status: 200 });
-    await api.notifications.getAll();
+    await api.feedItems.getAll();
 
     expect(fetch.mock.calls).toHaveLength(1);
 
     const mockUrl = fetch.mock.calls[0][0];
     const mockOptions = fetch.mock.calls[0][1];
 
-    expect(mockUrl).toBe(`${API_URL}/notifications?sort=-createdAt&page%5Blimit%5D=10&page%5Boffset%5D=0&include=user`);
+    expect(mockUrl).toBe(`${API_URL}/feedItems?sort=-createdAt&page%5Blimit%5D=10&page%5Boffset%5D=0&include=user`);
     expect(mockOptions.method).toBe(httpMethods.GET);
     expect(mockOptions.body).toBeNull();
   });

--- a/app/api/feedItems/index.js
+++ b/app/api/feedItems/index.js
@@ -1,0 +1,9 @@
+// @flow
+
+import getAll from './getAll';
+
+const feedItemsApi = {
+  getAll,
+};
+
+export default feedItemsApi;

--- a/app/api/index.js
+++ b/app/api/index.js
@@ -1,7 +1,7 @@
 // @flow
 
 import confirmation from './confirmation';
-import notifications from './notifications';
+import feedItems from './feedItems';
 import password from './password';
 import token from './token';
 import topics from './topics';
@@ -9,7 +9,7 @@ import users from './users';
 
 const api = {
   confirmation,
-  notifications,
+  feedItems,
   password,
   token,
   topics,

--- a/app/api/notifications/index.js
+++ b/app/api/notifications/index.js
@@ -1,9 +1,0 @@
-// @flow
-
-import getAll from './getAll';
-
-const notificationsApi = {
-  getAll,
-};
-
-export default notificationsApi;

--- a/app/config/api.js
+++ b/app/config/api.js
@@ -4,4 +4,4 @@
 export const API_URL = (window.config ? window.config.API_URL : 'http://owsdev.ugent.be/api');
 
 // API version
-export const API_VERSION = '3.0.0';
+export const API_VERSION = '4.0.0';

--- a/app/config/api.js
+++ b/app/config/api.js
@@ -1,7 +1,7 @@
 // @flow
 
 // API base URL
-export const API_URL = (window.config ? window.config.API_URL : 'http://owsdev.ugent.be/api');
+export const API_URL = (window.config ? window.config.API_URL : 'http://localhost:3000/api');
 
 // API version
 export const API_VERSION = '4.0.0';

--- a/app/modules/feed/saga/api/feedItems.js
+++ b/app/modules/feed/saga/api/feedItems.js
@@ -15,9 +15,9 @@ const mapEventTypeToPredicateType = {
   topic_updated: m.predicate.UPDATE,
 };
 
-export const apiGetNotificationsSaga = function* (action: a.FetchAction): Saga<void> {
+export const apiGetFeedItemsSaga = function* (action: a.FetchAction): Saga<void> {
   try {
-    const response = yield call(api.notifications.getAll);
+    const response = yield call(api.feedItems.getAll);
 
     // eslint-disable-next-line flowtype/no-weak-types
     const data = response.body.data.map((item: Object): m.Event => {

--- a/app/modules/feed/saga/api/index.js
+++ b/app/modules/feed/saga/api/index.js
@@ -7,11 +7,11 @@ import { all, takeLatest } from 'redux-saga/effects';
 
 import * as a from '../../actionTypes';
 
-import { apiGetNotificationsSaga } from './notifications';
+import { apiGetFeedItemsSaga } from './feedItems';
 
 const apiSaga = function* (): Saga<void> {
   yield all([
-    takeLatest(a.API_GET_NOTIFICATIONS, apiGetNotificationsSaga),
+    takeLatest(a.API_GET_NOTIFICATIONS, apiGetFeedItemsSaga),
   ]);
 };
 

--- a/app/modules/feed/saga/api/tests/feedItems.test.js
+++ b/app/modules/feed/saga/api/tests/feedItems.test.js
@@ -5,22 +5,22 @@ import { expectSaga } from 'redux-saga-test-plan';
 import api from 'api';
 
 import * as a from '../../../actionTypes';
-import { apiGetNotificationsSaga } from '../notifications';
+import { apiGetFeedItemsSaga } from '../feedItems';
 
-describe(` notifications`, (): void => {
+describe(`feedItems`, (): void => {
 
   beforeEach((): void => {
     fetch.resetMocks();
   });
 
-  describe(`apiGetNotificationsSaga`, (): void => {
+  describe(`apiGetFeedItemsSaga`, (): void => {
 
     it(`calls AuthApi.getAll and puts SET_FEED_ITEMS action`, (): void => {
       const dummyData = {
         data: [
           {
             id: '1',
-            type: 'notifications',
+            type: 'feedItems',
             attributes: {
               eventType: 'topic_created',
             },
@@ -45,12 +45,12 @@ describe(` notifications`, (): void => {
 
       fetch.mockResponseOnce(JSON.stringify(dummyData), { status: 200 });
 
-      const dummyGetNotificationsAction: a.ApiGetNotificationsAction = {
+      const dummyGetFeedItemsAction: a.ApiGetNotificationsAction = {
         type: a.API_GET_NOTIFICATIONS,
       };
 
-      return expectSaga(apiGetNotificationsSaga, dummyGetNotificationsAction)
-        .call(api.notifications.getAll)
+      return expectSaga(apiGetFeedItemsSaga, dummyGetFeedItemsAction)
+        .call(api.feedItems.getAll)
         .put.like({ action: { type: a.SET_EVENTS } })
         .run();
     });

--- a/app/modules/feed/saga/api/tests/index.test.js
+++ b/app/modules/feed/saga/api/tests/index.test.js
@@ -4,13 +4,13 @@ import { expectSaga } from 'redux-saga-test-plan';
 
 import apiSaga from '..';
 
-import { apiGetNotificationsSaga } from '../notifications';
+import { apiGetFeedItemsSaga } from '../feedItems';
 import * as a from '../../../actionTypes';
 
 describe(`apiSaga`, (): void => {
-  it(`takes every API_GET_NOTIFICATIONS action and forks apiGetNotificationsSaga`, (): void => {
+  it(`takes every API_GET_FEED_ITEMS action and forks apiGetFeedItemsSaga`, (): void => {
     return expectSaga(apiSaga)
-      .take(a.API_GET_NOTIFICATIONS, apiGetNotificationsSaga)
+      .take(a.API_GET_NOTIFICATIONS, apiGetFeedItemsSaga)
       .silentRun();
   });
 });


### PR DESCRIPTION
- Replace all references to `notifications` by `feedItems` in actions, sagas, components.
- Rename Feed.Event to Feed.FeedItem
- Rename all references to `events` by `feedItems`
- Bump API version

[Backlog item](https://trello.com/c/ftQImfKx/67-rename-notifications-to-feed-items)