### PR TITLE
Fix API config

### DIFF
--- a/app/config/api.js
+++ b/app/config/api.js
@@ -1,7 +1,7 @@
 // @flow
 
 // API base URL
-export const API_URL = (window.config ? window.config.API_URL : 'http://owsdev.ugent.be/api');
+export const API_URL = window.API_URL || 'http://owsdev.ugent.be/api';
 
 // API version
 export const API_VERSION = '4.0.0';

--- a/app/config/api.js
+++ b/app/config/api.js
@@ -1,7 +1,7 @@
 // @flow
 
 // API base URL
-export const API_URL = (window.config ? window.config.API_URL : 'http://localhost:3000/api');
+export const API_URL = (window.config ? window.config.API_URL : 'http://owsdev.ugent.be/api');
 
 // API version
 export const API_VERSION = '4.0.0';

--- a/app/config/api.js.erb
+++ b/app/config/api.js.erb
@@ -10,6 +10,4 @@
  *
  */
 
-window.config = {
-  API_URL: '<%= ENV['API_URL'] %>'
-};
+window.API_URL = '<%= ENV['API_URL'] %>';

--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,7 @@ React app for the OpenWebslides open-source co-creation platform.
 ## How to...
 
 - Run the webpack dev server: `yarn run dev-server`
+- Run the webpack dev server using a non-default API server: `API_URL=http://my-server.com/api yarn run dev-server`
 - Run tests:
   - Minimal output: `yarn run test`
   - Verbose test output + coverage report: `yarn run test-report`

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -120,6 +120,10 @@ const devConfig = {
   plugins: [
     // Include hot reloading functionality
     new webpack.HotModuleReplacementPlugin(),
+    // Allow specifying an API_URL override on the command line
+    new webpack.DefinePlugin({
+      'window.API_URL': process.env.API_URL ? `"${process.env.API_URL}"` : false,
+    }),
     new HtmlWebpackPlugin({
       template: path.join(paths.PUBLIC, 'index.dev.html'),
     }),


### PR DESCRIPTION
- Revert API endpoint change. 
- Allow specifying an API_URL using an environment variable, to prevent having to change the `api.js` file all the time. Usage:

```
$ API_URL=http://localhost:3000/api yarn run dev-server
```