### PR TITLE
Get Topic.rootContentItemId from topic request

### DIFF
--- a/app/modules/topics/saga/api/apiGet.js
+++ b/app/modules/topics/saga/api/apiGet.js
@@ -7,38 +7,10 @@ import api from 'api';
 import { UnexpectedHttpResponseError } from 'errors';
 import { type ApiResponseData } from 'lib/ApiRequest';
 import apiRequestsStatus from 'modules/apiRequestsStatus';
-import contentItems from 'modules/contentItems';
-// eslint-disable-next-line import/no-internal-modules
-import generateId from 'modules/contentItems/lib/generateId'; // #TODO
 
 import actions from '../../actions';
 import * as a from '../../actionTypes';
 import * as m from '../../model';
-
-const { contentItemTypes, contextTypes } = contentItems.model;
-
-const createInitialTopicRoot = function* (rootContentItemId: string): Saga<void> {
-  yield put(contentItems.actions.addToState(
-    rootContentItemId,
-    contentItemTypes.ROOT,
-    null,
-    {},
-  ));
-  const headingContentItemId = generateId();
-  yield put(contentItems.actions.addToState(
-    headingContentItemId,
-    contentItemTypes.HEADING,
-    {
-      contextType: contextTypes.PARENT,
-      contextItemId: rootContentItemId,
-    },
-    {
-      // #TODO prevent from being deleted
-      text: 'Placeholder',
-    },
-  ));
-  yield put(contentItems.actions.toggleEditing(headingContentItemId, true));
-};
 
 const apiGet = function* (action: a.ApiGetAction): Saga<void> {
   yield put(apiRequestsStatus.actions.setPending(action.type));
@@ -46,31 +18,20 @@ const apiGet = function* (action: a.ApiGetAction): Saga<void> {
   try {
     const { id } = action.payload;
     const topicsResponseData: ApiResponseData = yield call(api.topics.get, id);
-    const contentItemsResponseData: ApiResponseData = yield call(api.topics.getContent, id);
-    if (topicsResponseData.body == null || contentItemsResponseData.body == null) {
+    if (topicsResponseData.body == null) {
       throw new UnexpectedHttpResponseError();
     }
 
-    const rootContentItem = contentItemsResponseData.body.data.attributes.content[0];
-    let rootContentItemId: string;
-
-    if (rootContentItem == null) {
-      rootContentItemId = generateId();
-      yield call(createInitialTopicRoot, rootContentItemId);
-    }
-    else if (rootContentItem.type !== contentItemTypes.ROOT) {
-      throw new UnexpectedHttpResponseError(`Corrupted topic content for topic with id ${id}.`);
-    }
-    else {
-      rootContentItemId = rootContentItem.id;
+    const { attributes } = topicsResponseData.body.data;
+    if (attributes.rootContentItemId == null) {
+      throw new UnexpectedHttpResponseError(`Empty topic content item id topic with id ${id}.`);
     }
 
-    const { attributes: topicAttributes } = topicsResponseData.body.data;
     const topic: m.Topic = {
       id,
-      title: topicAttributes.title,
-      description: topicAttributes.description,
-      rootContentItemId,
+      title: attributes.title,
+      description: attributes.description,
+      rootContentItemId: attributes.rootContentItemId,
       isContentFetched: false,
     };
 


### PR DESCRIPTION
This PR ensures that the topic `rootContentItemId` is retrieved from the topic metadata request, and not from the content. Couple with API version >= 4.0.0, documentation is available at the usual address.

Summary: Topic now contains a `rootContentItemId` attribute, set at creation and unchangeable later. Every time content is written, the content's root content item is validated against this identifier.

TODO: somewhere in the topic create flow, add a `rootContentItemId` to the API request.