### PR TITLE
Pull Requests module and fetch/create actions

### DIFF
--- a/app/api/endpoints.js
+++ b/app/api/endpoints.js
@@ -5,6 +5,7 @@ export const USERS_ENDPOINT = '/users';
 export const PASSWORD_ENDPOINT = '/password';
 export const CONFIRMATION_ENDPOINT = '/confirmation';
 export const FEED_ITEMS_ENDPOINT = '/feedItems';
+export const PULL_REQUESTS_ENDPOINT = '/pullRequests';
 export const TOPICS_ENDPOINT = '/topics';
 export const TOPICS_FORK_ENDPOINT = '/fork';
 export const TOPICS_CONTENT_ENDPOINT = '/content';

--- a/app/api/index.js
+++ b/app/api/index.js
@@ -3,6 +3,7 @@
 import confirmation from './confirmation';
 import feedItems from './feedItems';
 import password from './password';
+import pullRequests from './pullRequests';
 import token from './token';
 import topics from './topics';
 import users from './users';
@@ -11,6 +12,7 @@ const api = {
   confirmation,
   feedItems,
   password,
+  pullRequests,
   token,
   topics,
   users,

--- a/app/api/pullRequests/get.js
+++ b/app/api/pullRequests/get.js
@@ -1,0 +1,20 @@
+// @flow
+
+/**
+ * GET on pull requests endpoint, retrieves a pull request
+ *
+ * API docs: https://openwebslides.github.io/documentation/#get-a-pull-request
+ */
+
+import ApiRequest, { httpMethods, type ApiResponseData } from 'lib/ApiRequest';
+
+import { PULL_REQUESTS_ENDPOINT } from '../endpoints';
+
+const get = (id: string): Promise<ApiResponseData> => {
+  return new ApiRequest(httpMethods.GET)
+    .addPathSegment(PULL_REQUESTS_ENDPOINT)
+    .addPathSegment(id)
+    .execute();
+};
+
+export default get;

--- a/app/api/pullRequests/get.test.js
+++ b/app/api/pullRequests/get.test.js
@@ -1,0 +1,29 @@
+// @flow
+
+import { API_URL } from 'config/api';
+import { httpMethods } from 'lib/ApiRequest';
+
+import api from '..';
+
+describe(`api.pullRequests.get`, (): void => {
+
+  beforeEach((): void => {
+    fetch.resetMocks();
+  });
+
+  it(`executes the correct fetch call`, async (): Promise<mixed> => {
+    const dummyPullRequestId = 'dummyPullRequestId';
+    fetch.mockResponseOnce('', { status: 200 });
+    await api.pullRequests.get(dummyPullRequestId);
+
+    expect(fetch.mock.calls).toHaveLength(1);
+
+    const mockUrl = fetch.mock.calls[0][0];
+    const mockOptions = fetch.mock.calls[0][1];
+
+    expect(mockUrl).toBe(`${API_URL}/pullRequests/${dummyPullRequestId}`);
+    expect(mockOptions.method).toBe(httpMethods.GET);
+    expect(mockOptions.body).toBeNull();
+  });
+
+});

--- a/app/api/pullRequests/index.js
+++ b/app/api/pullRequests/index.js
@@ -1,0 +1,9 @@
+// @flow
+
+import get from './get';
+
+const pullRequestApi = {
+  get,
+};
+
+export default pullRequestApi;

--- a/app/api/pullRequests/index.js
+++ b/app/api/pullRequests/index.js
@@ -1,9 +1,11 @@
 // @flow
 
 import get from './get';
+import post from './post';
 
 const pullRequestApi = {
   get,
+  post,
 };
 
 export default pullRequestApi;

--- a/app/api/pullRequests/post.js
+++ b/app/api/pullRequests/post.js
@@ -1,0 +1,49 @@
+// @flow
+
+/**
+ * POST on pullRequests endpoint, submit a new pull request
+ *
+ * API docs: https://openwebslides.github.io/documentation/#submit-a-pull-request
+ */
+
+import ApiRequest, { httpMethods, type ApiResponseData } from 'lib/ApiRequest';
+
+import { PULL_REQUESTS_ENDPOINT } from '../endpoints';
+
+const post = (
+  message: string,
+  topicId: string,
+  userId: string,
+  token: string,
+): Promise<ApiResponseData> => {
+  const body = JSON.stringify({
+    data: {
+      type: 'pullRequests',
+      attributes: {
+        message,
+      },
+      relationships: {
+        topic: {
+          data: {
+            id: topicId,
+            type: 'topics',
+          },
+        },
+        user: {
+          data: {
+            id: userId,
+            type: 'users',
+          },
+        },
+      },
+    },
+  });
+
+  return new ApiRequest(httpMethods.POST)
+    .addPathSegment(PULL_REQUESTS_ENDPOINT)
+    .setBody(body)
+    .setToken(token)
+    .execute();
+};
+
+export default post;

--- a/app/api/pullRequests/post.js
+++ b/app/api/pullRequests/post.js
@@ -12,7 +12,8 @@ import { PULL_REQUESTS_ENDPOINT } from '../endpoints';
 
 const post = (
   message: string,
-  topicId: string,
+  sourceTopicId: string,
+  targetTopicId: string,
   userId: string,
   token: string,
 ): Promise<ApiResponseData> => {
@@ -23,9 +24,15 @@ const post = (
         message,
       },
       relationships: {
-        topic: {
+        source: {
           data: {
-            id: topicId,
+            id: sourceTopicId,
+            type: 'topics',
+          },
+        },
+        target: {
+          data: {
+            id: targetTopicId,
             type: 'topics',
           },
         },

--- a/app/api/pullRequests/post.test.js
+++ b/app/api/pullRequests/post.test.js
@@ -13,11 +13,12 @@ describe(`api.pullRequests.post`, (): void => {
 
   it(`executes the correct fetch call`, async (): Promise<mixed> => {
     const dummyMessage = 'dummyMessage';
-    const dummyTopicId = 'dummyTopicId';
+    const dummySourceTopicId = 'dummySourceTopicId';
+    const dummyTargetTopicId = 'dummyTargetTopicId';
     const dummyUserId = 'dummyUserId';
     const dummyToken = 'dummyToken';
     fetch.mockResponseOnce('', { status: 200 });
-    await api.pullRequests.post(dummyMessage, dummyTopicId, dummyUserId, dummyToken);
+    await api.pullRequests.post(dummyMessage, dummySourceTopicId, dummyTargetTopicId, dummyUserId, dummyToken);
 
     expect(fetch.mock.calls).toHaveLength(1);
 
@@ -33,10 +34,16 @@ describe(`api.pullRequests.post`, (): void => {
           message: dummyMessage,
         },
         relationships: {
-          topic: {
+          source: {
             data: {
               type: 'topics',
-              id: dummyTopicId,
+              id: dummySourceTopicId,
+            },
+          },
+          target: {
+            data: {
+              type: 'topics',
+              id: dummyTargetTopicId,
             },
           },
           user: {

--- a/app/api/pullRequests/post.test.js
+++ b/app/api/pullRequests/post.test.js
@@ -1,0 +1,54 @@
+// @flow
+
+import { API_URL } from 'config/api';
+import { httpMethods } from 'lib/ApiRequest';
+
+import api from '..';
+
+describe(`api.pullRequests.post`, (): void => {
+
+  beforeEach((): void => {
+    fetch.resetMocks();
+  });
+
+  it(`executes the correct fetch call`, async (): Promise<mixed> => {
+    const dummyMessage = 'dummyMessage';
+    const dummyTopicId = 'dummyTopicId';
+    const dummyUserId = 'dummyUserId';
+    const dummyToken = 'dummyToken';
+    fetch.mockResponseOnce('', { status: 200 });
+    await api.pullRequests.post(dummyMessage, dummyTopicId, dummyUserId, dummyToken);
+
+    expect(fetch.mock.calls).toHaveLength(1);
+
+    const mockUrl = fetch.mock.calls[0][0];
+    const mockOptions = fetch.mock.calls[0][1];
+
+    expect(mockUrl).toBe(`${API_URL}/pullRequests`);
+    expect(mockOptions.method).toBe(httpMethods.POST);
+    expect(JSON.parse(mockOptions.body)).toStrictEqual({
+      data: {
+        type: 'pullRequests',
+        attributes: {
+          message: dummyMessage,
+        },
+        relationships: {
+          topic: {
+            data: {
+              type: 'topics',
+              id: dummyTopicId,
+            },
+          },
+          user: {
+            data: {
+              type: 'users',
+              id: dummyUserId,
+            },
+          },
+        },
+      },
+    });
+    expect(mockOptions.headers.Authorization).toBe(`Bearer ${dummyToken}`);
+  });
+
+});

--- a/app/lib/testResources/dummyPullRequestData.js
+++ b/app/lib/testResources/dummyPullRequestData.js
@@ -1,0 +1,48 @@
+// @flow
+
+import pullRequests from 'modules/pullRequests';
+
+export const pullRequest: pullRequests.model.PullRequest = {
+  id: 'dummyPullRequestId',
+  message: 'dummyPullRequestMessage',
+  topicId: 'dummyTopicId',
+  userId: 'dummyUserId',
+  state: pullRequests.model.pullRequestStates.OPEN,
+  timestamp: 1524490428,
+};
+
+export const pullRequest2: pullRequests.model.PullRequest = {
+  id: 'dummyPullRequest2Id',
+  message: 'dummyPullRequestMessage',
+  topicId: 'dummyTopicId',
+  userId: 'dummyUserId',
+  state: pullRequests.model.pullRequestStates.OPEN,
+  timestamp: 1524490408,
+};
+
+export const pullRequest3: pullRequests.model.PullRequest = {
+  id: 'dummyPullRequest3Id',
+  message: 'dummyPullRequestMessage',
+  topicId: 'dummyTopicId',
+  userId: 'dummyUserId',
+  state: pullRequests.model.pullRequestStates.OPEN,
+  timestamp: 1524490328,
+};
+
+export const rejectedPullRequest: pullRequests.model.PullRequest = {
+  id: 'dummyRejectedPullRequestId',
+  message: 'dummyPullRequestMessage',
+  topicId: 'dummyTopicId',
+  userId: 'dummyUserId',
+  state: pullRequests.model.pullRequestStates.REJECTED,
+  timestamp: 1524490308,
+};
+
+export const acceptedPullRequest: pullRequests.model.PullRequest = {
+  id: 'dummyAcceptedPullRequestId',
+  message: 'dummyPullRequestMessage',
+  topicId: 'dummyTopicId',
+  userId: 'dummyUserId',
+  state: pullRequests.model.pullRequestStates.ACCEPTED,
+  timestamp: 1524490228,
+};

--- a/app/lib/testResources/dummyPullRequestData.js
+++ b/app/lib/testResources/dummyPullRequestData.js
@@ -5,7 +5,8 @@ import pullRequests from 'modules/pullRequests';
 export const pullRequest: pullRequests.model.PullRequest = {
   id: 'dummyPullRequestId',
   message: 'dummyPullRequestMessage',
-  topicId: 'dummyTopicId',
+  sourceTopicId: 'dummySourceTopicId',
+  targetTopicId: 'dummyTargetTopicId',
   userId: 'dummyUserId',
   state: pullRequests.model.pullRequestStates.OPEN,
   timestamp: 1524490428,
@@ -14,7 +15,8 @@ export const pullRequest: pullRequests.model.PullRequest = {
 export const pullRequest2: pullRequests.model.PullRequest = {
   id: 'dummyPullRequest2Id',
   message: 'dummyPullRequestMessage',
-  topicId: 'dummyTopicId',
+  sourceTopicId: 'dummySourceTopicId',
+  targetTopicId: 'dummyTargetTopicId',
   userId: 'dummyUserId',
   state: pullRequests.model.pullRequestStates.OPEN,
   timestamp: 1524490408,
@@ -23,7 +25,8 @@ export const pullRequest2: pullRequests.model.PullRequest = {
 export const pullRequest3: pullRequests.model.PullRequest = {
   id: 'dummyPullRequest3Id',
   message: 'dummyPullRequestMessage',
-  topicId: 'dummyTopicId',
+  sourceTopicId: 'dummySourceTopicId',
+  targetTopicId: 'dummyTargetTopicId',
   userId: 'dummyUserId',
   state: pullRequests.model.pullRequestStates.OPEN,
   timestamp: 1524490328,
@@ -32,7 +35,8 @@ export const pullRequest3: pullRequests.model.PullRequest = {
 export const rejectedPullRequest: pullRequests.model.PullRequest = {
   id: 'dummyRejectedPullRequestId',
   message: 'dummyPullRequestMessage',
-  topicId: 'dummyTopicId',
+  sourceTopicId: 'dummySourceTopicId',
+  targetTopicId: 'dummyTargetTopicId',
   userId: 'dummyUserId',
   state: pullRequests.model.pullRequestStates.REJECTED,
   timestamp: 1524490308,
@@ -41,7 +45,8 @@ export const rejectedPullRequest: pullRequests.model.PullRequest = {
 export const acceptedPullRequest: pullRequests.model.PullRequest = {
   id: 'dummyAcceptedPullRequestId',
   message: 'dummyPullRequestMessage',
-  topicId: 'dummyTopicId',
+  sourceTopicId: 'dummySourceTopicId',
+  targetTopicId: 'dummyTargetTopicId',
   userId: 'dummyUserId',
   state: pullRequests.model.pullRequestStates.ACCEPTED,
   timestamp: 1524490228,

--- a/app/lib/testResources/index.js
+++ b/app/lib/testResources/index.js
@@ -4,6 +4,7 @@ import * as dummyAsyncRequestData from './dummyAsyncRequestData';
 import * as dummyContentItemData from './dummyContentItemData';
 import * as dummyFeedItemData from './dummyFeedItemData';
 import * as dummyErrorData from './dummyErrorData';
+import * as dummyPullRequestData from './dummyPullRequestData';
 import * as dummyTopicData from './dummyTopicData';
 import * as dummyUserData from './dummyUserData';
 import * as dummyProviderProps from './dummyProviderProps';
@@ -15,6 +16,7 @@ export {
   dummyContentItemData,
   dummyFeedItemData,
   dummyErrorData,
+  dummyPullRequestData,
   dummyTopicData,
   dummyUserData,
   dummyProviderProps,

--- a/app/modules/pullRequests/actionTypes/apiSaga.js
+++ b/app/modules/pullRequests/actionTypes/apiSaga.js
@@ -1,0 +1,28 @@
+// @flow
+
+/* eslint-disable no-multiple-empty-lines, flowtype/require-types-at-top */
+
+import { type ApiSagaAction } from 'types/actions';
+
+
+// Action constants --------------------------------------------------------------------------------
+
+export const API_GET: 'pullRequests/API_GET' = 'pullRequests/API_GET';
+
+
+// Action types ------------------------------------------------------------------------------------
+
+export type ApiGetAction = {|
+  ...ApiSagaAction,
+  type: typeof API_GET,
+  payload: {|
+    ...$PropertyType<ApiSagaAction, 'payload'>,
+    id: string,
+  |},
+|};
+
+
+// ApiSaga action ----------------------------------------------------------------------------------
+
+export type PullRequestsApiSagaAction =
+  | ApiGetAction;

--- a/app/modules/pullRequests/actionTypes/apiSaga.js
+++ b/app/modules/pullRequests/actionTypes/apiSaga.js
@@ -28,7 +28,8 @@ export type ApiPostAction = {|
   payload: {|
     ...$PropertyType<ApiSagaAction, 'payload'>,
     message: string,
-    topicId: string,
+    sourceTopicId: string,
+    targetTopicId: string,
     userId: string,
   |},
 |};

--- a/app/modules/pullRequests/actionTypes/apiSaga.js
+++ b/app/modules/pullRequests/actionTypes/apiSaga.js
@@ -8,6 +8,7 @@ import { type ApiSagaAction } from 'types/actions';
 // Action constants --------------------------------------------------------------------------------
 
 export const API_GET: 'pullRequests/API_GET' = 'pullRequests/API_GET';
+export const API_POST: 'pullRequests/API_POST' = 'pullRequests/API_POST';
 
 
 // Action types ------------------------------------------------------------------------------------
@@ -21,8 +22,20 @@ export type ApiGetAction = {|
   |},
 |};
 
+export type ApiPostAction = {|
+  ...ApiSagaAction,
+  type: typeof API_POST,
+  payload: {|
+    ...$PropertyType<ApiSagaAction, 'payload'>,
+    message: string,
+    topicId: string,
+    userId: string,
+  |},
+|};
+
 
 // ApiSaga action ----------------------------------------------------------------------------------
 
 export type PullRequestsApiSagaAction =
-  | ApiGetAction;
+  | ApiGetAction
+  | ApiPostAction;

--- a/app/modules/pullRequests/actionTypes/index.js
+++ b/app/modules/pullRequests/actionTypes/index.js
@@ -1,0 +1,14 @@
+// @flow
+
+import { type PullRequestsReducerAction } from './reducer';
+import { type PullRequestsApiSagaAction } from './apiSaga';
+import { type PullRequestsTaskSagaAction } from './taskSaga';
+
+export type PullRequestsAction =
+  | PullRequestsReducerAction
+  | PullRequestsApiSagaAction
+  | PullRequestsTaskSagaAction;
+
+export * from './reducer';
+export * from './apiSaga';
+export * from './taskSaga';

--- a/app/modules/pullRequests/actionTypes/reducer.js
+++ b/app/modules/pullRequests/actionTypes/reducer.js
@@ -1,0 +1,30 @@
+// @flow
+
+/* eslint-disable no-multiple-empty-lines, flowtype/require-types-at-top */
+
+import { type ReducerAction } from 'types/actions';
+
+import * as m from '../model';
+
+
+// Action constants --------------------------------------------------------------------------------
+
+export const SET_MULTIPLE_IN_STATE: 'pullRequests/SET_MULTIPLE_IN_STATE' = 'pullRequests/SET_MULTIPLE_IN_STATE';
+
+
+// Action types ------------------------------------------------------------------------------------
+
+export type SetMultipleInStateAction = {|
+  ...ReducerAction,
+  type: typeof SET_MULTIPLE_IN_STATE,
+  payload: {|
+    ...$PropertyType<ReducerAction, 'payload'>,
+    pullRequests: $ReadOnlyArray<m.PullRequest>,
+  |},
+|};
+
+
+// Reducer action ----------------------------------------------------------------------------------
+
+export type PullRequestsReducerAction =
+  | SetMultipleInStateAction;

--- a/app/modules/pullRequests/actionTypes/taskSaga.js
+++ b/app/modules/pullRequests/actionTypes/taskSaga.js
@@ -7,11 +7,23 @@ import { type TaskSagaAction } from 'types/actions';
 
 // Action constants --------------------------------------------------------------------------------
 
+export const CREATE: 'pullRequests/CREATE' = 'pullRequests/CREATE';
 export const FETCH: 'pullRequests/FETCH' = 'pullRequests/FETCH';
-export const SUBMIT: 'pullRequests/SUBMIT' = 'pullRequests/SUBMIT';
 
 
 // Action types ------------------------------------------------------------------------------------
+
+export type CreateAction = {|
+  ...TaskSagaAction,
+  type: typeof CREATE,
+  payload: {|
+    ...$PropertyType<TaskSagaAction, 'payload'>,
+    message: string,
+    sourceTopicId: string,
+    targetTopicId: string,
+    userId: string,
+  |},
+|};
 
 export type FetchAction = {|
   ...TaskSagaAction,
@@ -22,21 +34,9 @@ export type FetchAction = {|
   |},
 |};
 
-export type SubmitAction = {|
-  ...TaskSagaAction,
-  type: typeof SUBMIT,
-  payload: {|
-    ...$PropertyType<TaskSagaAction, 'payload'>,
-    message: string,
-    sourceTopicId: string,
-    targetTopicId: string,
-    userId: string,
-  |},
-|};
-
 
 // TaskSaga action ---------------------------------------------------------------------------------
 
 export type PullRequestsTaskSagaAction =
-  | FetchAction
-  | SubmitAction;
+  | CreateAction
+  | FetchAction;

--- a/app/modules/pullRequests/actionTypes/taskSaga.js
+++ b/app/modules/pullRequests/actionTypes/taskSaga.js
@@ -8,6 +8,7 @@ import { type TaskSagaAction } from 'types/actions';
 // Action constants --------------------------------------------------------------------------------
 
 export const FETCH: 'pullRequests/FETCH' = 'pullRequests/FETCH';
+export const SUBMIT: 'pullRequests/SUBMIT' = 'pullRequests/SUBMIT';
 
 
 // Action types ------------------------------------------------------------------------------------
@@ -21,8 +22,20 @@ export type FetchAction = {|
   |},
 |};
 
+export type SubmitAction = {|
+  ...TaskSagaAction,
+  type: typeof SUBMIT,
+  payload: {|
+    ...$PropertyType<TaskSagaAction, 'payload'>,
+    message: string,
+    topicId: string,
+    userId: string,
+  |},
+|};
+
 
 // TaskSaga action ---------------------------------------------------------------------------------
 
 export type PullRequestsTaskSagaAction =
-  | FetchAction;
+  | FetchAction
+  | SubmitAction;

--- a/app/modules/pullRequests/actionTypes/taskSaga.js
+++ b/app/modules/pullRequests/actionTypes/taskSaga.js
@@ -28,7 +28,8 @@ export type SubmitAction = {|
   payload: {|
     ...$PropertyType<TaskSagaAction, 'payload'>,
     message: string,
-    topicId: string,
+    sourceTopicId: string,
+    targetTopicId: string,
     userId: string,
   |},
 |};

--- a/app/modules/pullRequests/actionTypes/taskSaga.js
+++ b/app/modules/pullRequests/actionTypes/taskSaga.js
@@ -1,0 +1,28 @@
+// @flow
+
+/* eslint-disable no-multiple-empty-lines, flowtype/require-types-at-top */
+
+import { type TaskSagaAction } from 'types/actions';
+
+
+// Action constants --------------------------------------------------------------------------------
+
+export const FETCH: 'pullRequests/FETCH' = 'pullRequests/FETCH';
+
+
+// Action types ------------------------------------------------------------------------------------
+
+export type FetchAction = {|
+  ...TaskSagaAction,
+  type: typeof FETCH,
+  payload: {|
+    ...$PropertyType<TaskSagaAction, 'payload'>,
+    id: string,
+  |},
+|};
+
+
+// TaskSaga action ---------------------------------------------------------------------------------
+
+export type PullRequestsTaskSagaAction =
+  | FetchAction;

--- a/app/modules/pullRequests/actions/apiSaga/apiGet.js
+++ b/app/modules/pullRequests/actions/apiSaga/apiGet.js
@@ -1,0 +1,14 @@
+// @flow
+
+import * as a from '../../actionTypes';
+
+const apiGet = (id: string): a.ApiGetAction => {
+  return {
+    type: a.API_GET,
+    payload: {
+      id,
+    },
+  };
+};
+
+export default apiGet;

--- a/app/modules/pullRequests/actions/apiSaga/apiGet.test.js
+++ b/app/modules/pullRequests/actions/apiSaga/apiGet.test.js
@@ -1,0 +1,28 @@
+// @flow
+
+import * as a from '../../actionTypes';
+
+import actions from '..';
+
+describe(`apiGet`, (): void => {
+
+  let dummyId: string;
+
+  beforeEach((): void => {
+    dummyId = 'dummyId';
+  });
+
+  it(`returns a pullRequests API_GET action containing the passed arguments`, (): void => {
+    const expectedAction: a.ApiGetAction = {
+      type: a.API_GET,
+      payload: {
+        id: dummyId,
+      },
+    };
+    const actualAction = actions.apiGet(dummyId);
+
+    expect(actualAction).toStrictEqual(expectedAction);
+  });
+
+});
+

--- a/app/modules/pullRequests/actions/apiSaga/apiPost.js
+++ b/app/modules/pullRequests/actions/apiSaga/apiPost.js
@@ -6,13 +6,14 @@ import * as a from '../../actionTypes';
 
 const apiPost = (
   message: string,
-  topicId: string,
+  sourceTopicId: string,
+  targetTopicId: string,
   userId: string,
 ): a.ApiPostAction => {
   const validatedPayload = validate.stringProps(
-    ['message', 'topicId', 'userId'],
+    ['message', 'sourceTopicId', 'targetTopicId', 'userId'],
     [],
-    { message, topicId, userId },
+    { message, sourceTopicId, targetTopicId, userId },
   );
 
   return {

--- a/app/modules/pullRequests/actions/apiSaga/apiPost.js
+++ b/app/modules/pullRequests/actions/apiSaga/apiPost.js
@@ -1,0 +1,26 @@
+// @flow
+
+import validate from 'lib/validate';
+
+import * as a from '../../actionTypes';
+
+const apiPost = (
+  message: string,
+  topicId: string,
+  userId: string,
+): a.ApiPostAction => {
+  const validatedPayload = validate.stringProps(
+    ['message', 'topicId', 'userId'],
+    [],
+    { message, topicId, userId },
+  );
+
+  return {
+    type: a.API_POST,
+    payload: {
+      ...validatedPayload,
+    },
+  };
+};
+
+export default apiPost;

--- a/app/modules/pullRequests/actions/apiSaga/apiPost.js
+++ b/app/modules/pullRequests/actions/apiSaga/apiPost.js
@@ -11,7 +11,7 @@ const apiPost = (
   userId: string,
 ): a.ApiPostAction => {
   const validatedPayload = validate.stringProps(
-    ['message', 'sourceTopicId', 'targetTopicId', 'userId'],
+    ['message'],
     [],
     { message, sourceTopicId, targetTopicId, userId },
   );

--- a/app/modules/pullRequests/actions/apiSaga/apiPost.test.js
+++ b/app/modules/pullRequests/actions/apiSaga/apiPost.test.js
@@ -41,7 +41,7 @@ describe(`apiPost`, (): void => {
     const actualAction = actions.apiPost(dummyMessage, dummySourceTopicId, dummyTargetTopicId, dummyUserId);
 
     expect(validate.stringProps).toHaveBeenCalledWith(
-      ['message', 'sourceTopicId', 'targetTopicId', 'userId'],
+      ['message'],
       [],
       {
         message: dummyMessage,

--- a/app/modules/pullRequests/actions/apiSaga/apiPost.test.js
+++ b/app/modules/pullRequests/actions/apiSaga/apiPost.test.js
@@ -1,0 +1,52 @@
+// @flow
+
+import validate from 'lib/validate';
+
+import * as a from '../../actionTypes';
+
+import actions from '..';
+
+describe(`apiPost`, (): void => {
+
+  let dummyMessage: string;
+  let dummyTopicId: string;
+  let dummyUserId: string;
+
+  beforeEach((): void => {
+    dummyMessage = 'dummyMessage';
+    dummyTopicId = 'dummyTopicId';
+    dummyUserId = 'dummyUserId';
+  });
+
+  it(`returns a pullRequests API_POST action containing the passed arguments`, (): void => {
+    const expectedAction: a.ApiPostAction = {
+      type: a.API_POST,
+      payload: {
+        message: dummyMessage,
+        topicId: dummyTopicId,
+        userId: dummyUserId,
+      },
+    };
+    const actualAction = actions.apiPost(dummyMessage, dummyTopicId, dummyUserId);
+
+    expect(actualAction).toStrictEqual(expectedAction);
+  });
+
+  it(`calls validate.stringProps with the correct arguments and passes the result into the action`, (): void => {
+    const dummyValidatedProps = { dummy: 'props' };
+    validate.stringProps = jest.fn((): any => dummyValidatedProps);
+    const actualAction = actions.apiPost(dummyMessage, dummyTopicId, dummyUserId);
+
+    expect(validate.stringProps).toHaveBeenCalledWith(
+      ['message', 'topicId', 'userId'],
+      [],
+      {
+        message: dummyMessage,
+        topicId: dummyTopicId,
+        userId: dummyUserId,
+      },
+    );
+    expect(actualAction.payload).toStrictEqual(dummyValidatedProps);
+  });
+
+});

--- a/app/modules/pullRequests/actions/apiSaga/apiPost.test.js
+++ b/app/modules/pullRequests/actions/apiSaga/apiPost.test.js
@@ -9,12 +9,14 @@ import actions from '..';
 describe(`apiPost`, (): void => {
 
   let dummyMessage: string;
-  let dummyTopicId: string;
+  let dummySourceTopicId: string;
+  let dummyTargetTopicId: string;
   let dummyUserId: string;
 
   beforeEach((): void => {
     dummyMessage = 'dummyMessage';
-    dummyTopicId = 'dummyTopicId';
+    dummySourceTopicId = 'dummySourceTopicId';
+    dummyTargetTopicId = 'dummyTargetTopicId';
     dummyUserId = 'dummyUserId';
   });
 
@@ -23,11 +25,12 @@ describe(`apiPost`, (): void => {
       type: a.API_POST,
       payload: {
         message: dummyMessage,
-        topicId: dummyTopicId,
+        sourceTopicId: dummySourceTopicId,
+        targetTopicId: dummyTargetTopicId,
         userId: dummyUserId,
       },
     };
-    const actualAction = actions.apiPost(dummyMessage, dummyTopicId, dummyUserId);
+    const actualAction = actions.apiPost(dummyMessage, dummySourceTopicId, dummyTargetTopicId, dummyUserId);
 
     expect(actualAction).toStrictEqual(expectedAction);
   });
@@ -35,14 +38,15 @@ describe(`apiPost`, (): void => {
   it(`calls validate.stringProps with the correct arguments and passes the result into the action`, (): void => {
     const dummyValidatedProps = { dummy: 'props' };
     validate.stringProps = jest.fn((): any => dummyValidatedProps);
-    const actualAction = actions.apiPost(dummyMessage, dummyTopicId, dummyUserId);
+    const actualAction = actions.apiPost(dummyMessage, dummySourceTopicId, dummyTargetTopicId, dummyUserId);
 
     expect(validate.stringProps).toHaveBeenCalledWith(
-      ['message', 'topicId', 'userId'],
+      ['message', 'sourceTopicId', 'targetTopicId', 'userId'],
       [],
       {
         message: dummyMessage,
-        topicId: dummyTopicId,
+        sourceTopicId: dummySourceTopicId,
+        targetTopicId: dummyTargetTopicId,
         userId: dummyUserId,
       },
     );

--- a/app/modules/pullRequests/actions/apiSaga/index.js
+++ b/app/modules/pullRequests/actions/apiSaga/index.js
@@ -1,0 +1,9 @@
+// @flow
+
+import apiGet from './apiGet';
+
+const apiSagaActions = {
+  apiGet,
+};
+
+export default apiSagaActions;

--- a/app/modules/pullRequests/actions/apiSaga/index.js
+++ b/app/modules/pullRequests/actions/apiSaga/index.js
@@ -1,9 +1,11 @@
 // @flow
 
 import apiGet from './apiGet';
+import apiPost from './apiPost';
 
 const apiSagaActions = {
   apiGet,
+  apiPost,
 };
 
 export default apiSagaActions;

--- a/app/modules/pullRequests/actions/index.js
+++ b/app/modules/pullRequests/actions/index.js
@@ -1,0 +1,13 @@
+// @flow
+
+import reducerActions from './reducer';
+import apiSagaActions from './apiSaga';
+import taskSagaActions from './taskSaga';
+
+const actions = {
+  ...reducerActions,
+  ...apiSagaActions,
+  ...taskSagaActions,
+};
+
+export default actions;

--- a/app/modules/pullRequests/actions/reducer/index.js
+++ b/app/modules/pullRequests/actions/reducer/index.js
@@ -1,0 +1,9 @@
+// @flow
+
+import setMultipleInState from './setMultipleInState';
+
+const reducerActions = {
+  setMultipleInState,
+};
+
+export default reducerActions;

--- a/app/modules/pullRequests/actions/reducer/setMultipleInState.js
+++ b/app/modules/pullRequests/actions/reducer/setMultipleInState.js
@@ -1,0 +1,17 @@
+// @flow
+
+import * as a from '../../actionTypes';
+import * as m from '../../model';
+
+const setMultipleInState = (
+  pullRequests: $ReadOnlyArray<m.PullRequest>,
+): a.SetMultipleInStateAction => {
+  return {
+    type: a.SET_MULTIPLE_IN_STATE,
+    payload: {
+      pullRequests,
+    },
+  };
+};
+
+export default setMultipleInState;

--- a/app/modules/pullRequests/actions/reducer/setMultipleInState.test.js
+++ b/app/modules/pullRequests/actions/reducer/setMultipleInState.test.js
@@ -1,0 +1,33 @@
+// @flow
+
+import { dummyPullRequestData } from 'lib/testResources';
+
+import * as a from '../../actionTypes';
+import * as m from '../../model';
+
+import actions from '..';
+
+describe(`setMultipleInState`, (): void => {
+
+  let dummyPullRequests: $ReadOnlyArray<m.PullRequest>;
+
+  beforeEach((): void => {
+    dummyPullRequests = [
+      { ...dummyPullRequestData.pullRequest },
+      { ...dummyPullRequestData.pullRequest2 },
+    ];
+  });
+
+  it(`returns a pullRequests SET_MULTIPLE_IN_STATE action containing the passed arguments`, (): void => {
+    const expectedAction: a.SetMultipleInStateAction = {
+      type: a.SET_MULTIPLE_IN_STATE,
+      payload: {
+        pullRequests: dummyPullRequests,
+      },
+    };
+    const actualAction = actions.setMultipleInState(dummyPullRequests);
+
+    expect(actualAction).toStrictEqual(expectedAction);
+  });
+
+});

--- a/app/modules/pullRequests/actions/taskSaga/create.js
+++ b/app/modules/pullRequests/actions/taskSaga/create.js
@@ -2,14 +2,14 @@
 
 import * as a from '../../actionTypes';
 
-const submit = (
+const create = (
   message: string,
   sourceTopicId: string,
   targetTopicId: string,
   userId: string,
-): a.SubmitAction => {
+): a.CreateAction => {
   return {
-    type: a.SUBMIT,
+    type: a.CREATE,
     payload: {
       message,
       sourceTopicId,
@@ -19,4 +19,4 @@ const submit = (
   };
 };
 
-export default submit;
+export default create;

--- a/app/modules/pullRequests/actions/taskSaga/create.test.js
+++ b/app/modules/pullRequests/actions/taskSaga/create.test.js
@@ -4,7 +4,7 @@ import * as a from '../../actionTypes';
 
 import actions from '..';
 
-describe(`submit`, (): void => {
+describe(`create`, (): void => {
 
   let dummyMessage: string;
   let dummySourceTopicId: string;
@@ -18,9 +18,9 @@ describe(`submit`, (): void => {
     dummyUserId = 'dummyUserId';
   });
 
-  it(`returns a pullRequests SUBMIT action containing the passed arguments`, (): void => {
-    const expectedAction: a.SubmitAction = {
-      type: a.SUBMIT,
+  it(`returns a pullRequests CREATE action containing the passed arguments`, (): void => {
+    const expectedAction: a.CreateAction = {
+      type: a.CREATE,
       payload: {
         message: dummyMessage,
         sourceTopicId: dummySourceTopicId,
@@ -28,7 +28,7 @@ describe(`submit`, (): void => {
         userId: dummyUserId,
       },
     };
-    const actualAction = actions.submit(dummyMessage, dummySourceTopicId, dummyTargetTopicId, dummyUserId);
+    const actualAction = actions.create(dummyMessage, dummySourceTopicId, dummyTargetTopicId, dummyUserId);
 
     expect(actualAction).toStrictEqual(expectedAction);
   });

--- a/app/modules/pullRequests/actions/taskSaga/fetch.js
+++ b/app/modules/pullRequests/actions/taskSaga/fetch.js
@@ -1,0 +1,14 @@
+// @flow
+
+import * as a from '../../actionTypes';
+
+const fetch = (id: string): a.FetchAction => {
+  return {
+    type: a.FETCH,
+    payload: {
+      id,
+    },
+  };
+};
+
+export default fetch;

--- a/app/modules/pullRequests/actions/taskSaga/fetch.test.js
+++ b/app/modules/pullRequests/actions/taskSaga/fetch.test.js
@@ -1,0 +1,27 @@
+// @flow
+
+import * as a from '../../actionTypes';
+
+import actions from '..';
+
+describe(`fetch`, (): void => {
+
+  let dummyId: string;
+
+  beforeEach((): void => {
+    dummyId = 'dummyId';
+  });
+
+  it(`returns a pullRequests FETCH action containing the passed arguments`, (): void => {
+    const expectedAction: a.FetchAction = {
+      type: a.FETCH,
+      payload: {
+        id: dummyId,
+      },
+    };
+    const actualAction = actions.fetch(dummyId);
+
+    expect(actualAction).toStrictEqual(expectedAction);
+  });
+
+});

--- a/app/modules/pullRequests/actions/taskSaga/index.js
+++ b/app/modules/pullRequests/actions/taskSaga/index.js
@@ -1,11 +1,11 @@
 // @flow
 
+import create from './create';
 import fetch from './fetch';
-import submit from './submit';
 
 const taskSagaActions = {
+  create,
   fetch,
-  submit,
 };
 
 export default taskSagaActions;

--- a/app/modules/pullRequests/actions/taskSaga/index.js
+++ b/app/modules/pullRequests/actions/taskSaga/index.js
@@ -1,0 +1,9 @@
+// @flow
+
+import fetch from './fetch';
+
+const taskSagaActions = {
+  fetch,
+};
+
+export default taskSagaActions;

--- a/app/modules/pullRequests/actions/taskSaga/index.js
+++ b/app/modules/pullRequests/actions/taskSaga/index.js
@@ -1,9 +1,11 @@
 // @flow
 
 import fetch from './fetch';
+import submit from './submit';
 
 const taskSagaActions = {
   fetch,
+  submit,
 };
 
 export default taskSagaActions;

--- a/app/modules/pullRequests/actions/taskSaga/submit.js
+++ b/app/modules/pullRequests/actions/taskSaga/submit.js
@@ -2,12 +2,18 @@
 
 import * as a from '../../actionTypes';
 
-const submit = (message: string, topicId: string, userId: string): a.SubmitAction => {
+const submit = (
+  message: string,
+  sourceTopicId: string,
+  targetTopicId: string,
+  userId: string,
+): a.SubmitAction => {
   return {
     type: a.SUBMIT,
     payload: {
       message,
-      topicId,
+      sourceTopicId,
+      targetTopicId,
       userId,
     },
   };

--- a/app/modules/pullRequests/actions/taskSaga/submit.js
+++ b/app/modules/pullRequests/actions/taskSaga/submit.js
@@ -1,0 +1,16 @@
+// @flow
+
+import * as a from '../../actionTypes';
+
+const submit = (message: string, topicId: string, userId: string): a.SubmitAction => {
+  return {
+    type: a.SUBMIT,
+    payload: {
+      message,
+      topicId,
+      userId,
+    },
+  };
+};
+
+export default submit;

--- a/app/modules/pullRequests/actions/taskSaga/submit.test.js
+++ b/app/modules/pullRequests/actions/taskSaga/submit.test.js
@@ -7,12 +7,14 @@ import actions from '..';
 describe(`submit`, (): void => {
 
   let dummyMessage: string;
-  let dummyTopicId: string;
+  let dummySourceTopicId: string;
+  let dummyTargetTopicId: string;
   let dummyUserId: string;
 
   beforeEach((): void => {
     dummyMessage = 'dummyMessage';
-    dummyTopicId = 'dummyTopicId';
+    dummySourceTopicId = 'dummySourceTopicId';
+    dummyTargetTopicId = 'dummyTargetTopicId';
     dummyUserId = 'dummyUserId';
   });
 
@@ -21,11 +23,12 @@ describe(`submit`, (): void => {
       type: a.SUBMIT,
       payload: {
         message: dummyMessage,
-        topicId: dummyTopicId,
+        sourceTopicId: dummySourceTopicId,
+        targetTopicId: dummyTargetTopicId,
         userId: dummyUserId,
       },
     };
-    const actualAction = actions.submit(dummyMessage, dummyTopicId, dummyUserId);
+    const actualAction = actions.submit(dummyMessage, dummySourceTopicId, dummyTargetTopicId, dummyUserId);
 
     expect(actualAction).toStrictEqual(expectedAction);
   });

--- a/app/modules/pullRequests/actions/taskSaga/submit.test.js
+++ b/app/modules/pullRequests/actions/taskSaga/submit.test.js
@@ -1,0 +1,33 @@
+// @flow
+
+import * as a from '../../actionTypes';
+
+import actions from '..';
+
+describe(`submit`, (): void => {
+
+  let dummyMessage: string;
+  let dummyTopicId: string;
+  let dummyUserId: string;
+
+  beforeEach((): void => {
+    dummyMessage = 'dummyMessage';
+    dummyTopicId = 'dummyTopicId';
+    dummyUserId = 'dummyUserId';
+  });
+
+  it(`returns a pullRequests SUBMIT action containing the passed arguments`, (): void => {
+    const expectedAction: a.SubmitAction = {
+      type: a.SUBMIT,
+      payload: {
+        message: dummyMessage,
+        topicId: dummyTopicId,
+        userId: dummyUserId,
+      },
+    };
+    const actualAction = actions.submit(dummyMessage, dummyTopicId, dummyUserId);
+
+    expect(actualAction).toStrictEqual(expectedAction);
+  });
+
+});

--- a/app/modules/pullRequests/components/index.js
+++ b/app/modules/pullRequests/components/index.js
@@ -1,0 +1,10 @@
+// @flow
+
+const index = {
+};
+
+/* istanbul ignore next */
+// $FlowFixMe Necessary to make hot loading work for components through index files
+if (module.hot) module.hot.accept();
+
+export default index;

--- a/app/modules/pullRequests/index.js
+++ b/app/modules/pullRequests/index.js
@@ -1,0 +1,19 @@
+// @flow
+
+import actions from './actions';
+import components from './components';
+import * as model from './model';
+import reducer from './reducer';
+import selectors from './selectors';
+import saga from './saga';
+
+const pullRequests = {
+  actions,
+  components,
+  model,
+  reducer,
+  saga,
+  selectors,
+};
+
+export default pullRequests;

--- a/app/modules/pullRequests/index.js
+++ b/app/modules/pullRequests/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import actions from './actions';
+import * as actionTypes from './actionTypes';
 import components from './components';
 import * as model from './model';
 import reducer from './reducer';
@@ -9,6 +10,7 @@ import saga from './saga';
 
 const pullRequests = {
   actions,
+  actionTypes,
   components,
   model,
   reducer,

--- a/app/modules/pullRequests/model/index.js
+++ b/app/modules/pullRequests/model/index.js
@@ -17,8 +17,8 @@ export type PullRequestState = $Values<typeof pullRequestStates>;
 export type PullRequest = {|
   +id: string,
   +message: string,
-  // Identifier of forked topic
-  +topicId: string,
+  +sourceTopicId: string,
+  +targetTopicId: string,
   +userId: string,
   +state: PullRequestState,
   +timestamp: number,

--- a/app/modules/pullRequests/model/index.js
+++ b/app/modules/pullRequests/model/index.js
@@ -1,0 +1,34 @@
+// @flow
+
+/* eslint-disable flowtype/require-types-at-top */
+
+const OPEN: 'pullRequestStates/OPEN' = 'pullRequestStates/OPEN';
+const ACCEPTED: 'pullRequestStates/ACCEPTED' = 'pullRequestStates/ACCEPTED';
+const REJECTED: 'pullRequestStates/REJECTED' = 'pullRequestStates/REJECTED';
+
+export const pullRequestStates = {
+  OPEN,
+  ACCEPTED,
+  REJECTED,
+};
+
+export type PullRequestState = $Values<typeof pullRequestStates>;
+
+export type PullRequest = {|
+  +id: string,
+  +message: string,
+  // Identifier of forked topic
+  +topicId: string,
+  +userId: string,
+  +state: PullRequestState,
+  +timestamp: number,
+|};
+
+// eslint-disable-next-line flowtype/require-exact-type
+export type PullRequestsById = {
+  +[id: string]: PullRequest,
+};
+
+export type PullRequestsState = {|
+  +byId: PullRequestsById,
+|};

--- a/app/modules/pullRequests/reducer/index.js
+++ b/app/modules/pullRequests/reducer/index.js
@@ -1,0 +1,27 @@
+// @flow
+
+import * as a from '../actionTypes';
+import * as m from '../model';
+
+import setMultipleInState from './setMultipleInState';
+
+const initialState: m.PullRequestsState = {
+  byId: {},
+};
+
+const reducer = (
+  state: m.PullRequestsState = initialState,
+  action: a.PullRequestsReducerAction,
+): m.PullRequestsState => {
+  switch (action.type) {
+    case a.SET_MULTIPLE_IN_STATE:
+      return setMultipleInState(state, action);
+    default:
+      // Make sure a flow type error is thrown when not all action.type cases are handled
+      (action: empty);
+      return state;
+  }
+};
+
+export { initialState };
+export default reducer;

--- a/app/modules/pullRequests/reducer/setMultipleInState.js
+++ b/app/modules/pullRequests/reducer/setMultipleInState.js
@@ -1,0 +1,29 @@
+// @flow
+
+import * as a from '../actionTypes';
+import * as m from '../model';
+
+const setMultipleInState = (
+  state: m.PullRequestsState,
+  action: a.SetMultipleInStateAction,
+): m.PullRequestsState => {
+  const { pullRequests } = action.payload;
+
+  if (pullRequests.length === 0) {
+    return state;
+  }
+  else {
+    const newById = { ...state.byId };
+
+    pullRequests.forEach((pullRequest: m.PullRequest): void => {
+      newById[pullRequest.id] = pullRequest;
+    });
+
+    return {
+      ...state,
+      byId: newById,
+    };
+  }
+};
+
+export default setMultipleInState;

--- a/app/modules/pullRequests/reducer/setMultipleInState.test.js
+++ b/app/modules/pullRequests/reducer/setMultipleInState.test.js
@@ -1,0 +1,97 @@
+// @flow
+
+import { dummyPullRequestData } from 'lib/testResources';
+
+import * as a from '../actionTypes';
+import * as m from '../model';
+
+import reducer from '.';
+
+describe(`setMultipleInState`, (): void => {
+
+  let dummyPullRequest1: m.PullRequest;
+  let dummyPullRequest2: m.PullRequest;
+  let dummyPullRequest3: m.PullRequest;
+
+  beforeEach((): void => {
+    dummyPullRequest1 = { ...dummyPullRequestData.pullRequest };
+    dummyPullRequest2 = { ...dummyPullRequestData.pullRequest2 };
+    dummyPullRequest3 = { ...dummyPullRequestData.pullRequest3 };
+  });
+
+  it(`sets the passed pullRequests in the state`, (): void => {
+    const prevState: m.PullRequestsState = {
+      byId: {
+        [dummyPullRequest1.id]: dummyPullRequest1,
+      },
+    };
+    const setMultipleInStateAction: a.SetMultipleInStateAction = {
+      type: a.SET_MULTIPLE_IN_STATE,
+      payload: {
+        pullRequests: [dummyPullRequest2, dummyPullRequest3],
+      },
+    };
+    const nextState: m.PullRequestsState = {
+      byId: {
+        [dummyPullRequest1.id]: dummyPullRequest1,
+        [dummyPullRequest2.id]: dummyPullRequest2,
+        [dummyPullRequest3.id]: dummyPullRequest3,
+      },
+    };
+    const resultState = reducer(prevState, setMultipleInStateAction);
+
+    expect(resultState).toStrictEqual(nextState);
+    expect(resultState).not.toBe(prevState);
+    expect(resultState.byId).not.toBe(prevState.byId);
+  });
+
+  it(`overrides existing pullRequests, when the id of an existing pullRequest is the same as the id of one of the passed pullRequests`, (): void => {
+    const editedDummyPullRequest2 = { ...dummyPullRequest2, state: m.pullRequestStates.REJECTED };
+    const prevState: m.PullRequestsState = {
+      byId: {
+        [dummyPullRequest1.id]: dummyPullRequest1,
+        [dummyPullRequest2.id]: dummyPullRequest2,
+      },
+    };
+    const setMultipleInStateAction: a.SetMultipleInStateAction = {
+      type: a.SET_MULTIPLE_IN_STATE,
+      payload: {
+        pullRequests: [editedDummyPullRequest2, dummyPullRequest3],
+      },
+    };
+    const nextState: m.PullRequestsState = {
+      byId: {
+        [dummyPullRequest1.id]: dummyPullRequest1,
+        [dummyPullRequest2.id]: editedDummyPullRequest2,
+        [dummyPullRequest3.id]: dummyPullRequest3,
+      },
+    };
+    const resultState = reducer(prevState, setMultipleInStateAction);
+
+    expect(resultState).toStrictEqual(nextState);
+    expect(resultState).not.toBe(prevState);
+    expect(resultState.byId).not.toBe(prevState.byId);
+    expect(resultState.byId[dummyPullRequest2.id]).not.toBe(prevState.byId[dummyPullRequest2.id]);
+  });
+
+  it(`returns the state unchanged, when the passed pullRequests array is empty`, (): void => {
+    const prevState: m.PullRequestsState = {
+      byId: {
+        [dummyPullRequest1.id]: dummyPullRequest1,
+        [dummyPullRequest2.id]: dummyPullRequest2,
+      },
+    };
+    const setMultipleInStateAction: a.SetMultipleInStateAction = {
+      type: a.SET_MULTIPLE_IN_STATE,
+      payload: {
+        pullRequests: [],
+      },
+    };
+    const resultState = reducer(prevState, setMultipleInStateAction);
+
+    expect(resultState).toStrictEqual(prevState);
+    expect(resultState).toBe(prevState);
+    expect(resultState.byId).toBe(prevState.byId);
+  });
+
+});

--- a/app/modules/pullRequests/saga/api/apiGet.js
+++ b/app/modules/pullRequests/saga/api/apiGet.js
@@ -29,7 +29,8 @@ const apiGet = function* (action: a.ApiGetAction): Saga<void> {
   const pullRequest: m.PullRequest = {
     id,
     message: attributes.message,
-    topicId: relationships.topic.data.id,
+    sourceTopicId: relationships.source.data.id,
+    targetTopicId: relationships.target.data.id,
     userId: relationships.user.data.id,
     state: apiPullRequestStatesMap[attributes.state],
     timestamp: Number(meta.createdAt) * 1000,

--- a/app/modules/pullRequests/saga/api/apiGet.js
+++ b/app/modules/pullRequests/saga/api/apiGet.js
@@ -1,0 +1,41 @@
+// @flow
+
+import { type Saga } from 'redux-saga';
+import { call, put } from 'redux-saga/effects';
+
+import api from 'api';
+import { UnexpectedHttpResponseError } from 'errors';
+import { type ApiResponseData } from 'lib/ApiRequest';
+
+import actions from '../../actions';
+import * as a from '../../actionTypes';
+import * as m from '../../model';
+
+const apiPullRequestStatesMap = {
+  open: m.pullRequestStates.OPEN,
+  accepted: m.pullRequestStates.ACCEPTED,
+  rejected: m.pullRequestStates.REJECTED,
+};
+
+const apiGet = function* (action: a.ApiGetAction): Saga<void> {
+  const { id } = action.payload;
+  const pullRequestsResponseData: ApiResponseData = yield call(api.pullRequests.get, id);
+  if (pullRequestsResponseData.body == null) {
+    throw new UnexpectedHttpResponseError();
+  }
+
+  const { attributes, relationships, meta } = pullRequestsResponseData.body.data;
+
+  const pullRequest: m.PullRequest = {
+    id,
+    message: attributes.message,
+    topicId: relationships.topic.data.id,
+    userId: relationships.user.data.id,
+    state: apiPullRequestStatesMap[attributes.state],
+    timestamp: Number(meta.createdAt) * 1000,
+  };
+
+  yield put(actions.setMultipleInState([pullRequest]));
+};
+
+export default apiGet;

--- a/app/modules/pullRequests/saga/api/apiGet.test.js
+++ b/app/modules/pullRequests/saga/api/apiGet.test.js
@@ -1,0 +1,75 @@
+// @flow
+
+import { expectSaga } from 'redux-saga-test-plan';
+import { call } from 'redux-saga/effects';
+
+import api from 'api';
+import { UnexpectedHttpResponseError } from 'errors';
+
+import actions from '../../actions';
+import { pullRequestStates } from '../../model';
+
+import { sagas } from '..';
+
+describe(`apiGet`, (): void => {
+
+  let dummyId: string;
+  let dummyMessage: string;
+  let dummyTopicId: string;
+  let dummyUserId: string;
+  let dummyState: string;
+  let dummyCreatedAt: number;
+
+  beforeEach((): void => {
+    dummyId = 'dummyId';
+    dummyMessage = 'dummyMessage';
+    dummyTopicId = 'dummyTopicId';
+    dummyUserId = 'dummyUserId';
+    dummyState = 'open';
+    dummyCreatedAt = 1540308640;
+  });
+
+  it(`sends a GET request for the passed id to the pullRequests endpoint, processes the response and puts the pull request in the state`, (): void => {
+    const dummyAction = actions.apiGet(dummyId);
+    const dummyApiResponse = {
+      status: 200,
+      body: {
+        data: {
+          attributes: {
+            message: dummyMessage,
+            state: dummyState,
+          },
+          relationships: {
+            topic: { data: { id: dummyTopicId } },
+            user: { data: { id: dummyUserId } },
+          },
+          meta: { createdAt: dummyCreatedAt },
+        },
+      },
+    };
+
+    return expectSaga(sagas.apiGet, dummyAction)
+      .provide([
+        [call(api.pullRequests.get, dummyId), dummyApiResponse],
+      ])
+      .call(api.pullRequests.get, dummyId)
+      .put(actions.setMultipleInState([{ id: dummyId, message: dummyMessage, topicId: dummyTopicId, userId: dummyUserId, state: pullRequestStates.OPEN, timestamp: (dummyCreatedAt * 1000) }]))
+      .run();
+  });
+
+  it(`throws an UnexpectedHttpResponseError, when the api response does not contain a body`, async (): Promise<mixed> => {
+    const dummyAction = actions.apiGet(dummyId);
+    const dummyApiResponse = { status: 200, body: null };
+
+    // Suppress console.error from redux-saga $FlowFixMe
+    console.error = jest.fn();
+    await expect(
+      expectSaga(sagas.apiGet, dummyAction)
+        .provide([
+          [call(api.pullRequests.get, dummyId), dummyApiResponse],
+        ])
+        .run(),
+    ).rejects.toBeInstanceOf(UnexpectedHttpResponseError);
+  });
+
+});

--- a/app/modules/pullRequests/saga/api/apiGet.test.js
+++ b/app/modules/pullRequests/saga/api/apiGet.test.js
@@ -15,7 +15,8 @@ describe(`apiGet`, (): void => {
 
   let dummyId: string;
   let dummyMessage: string;
-  let dummyTopicId: string;
+  let dummySourceTopicId: string;
+  let dummyTargetTopicId: string;
   let dummyUserId: string;
   let dummyState: string;
   let dummyCreatedAt: number;
@@ -23,7 +24,8 @@ describe(`apiGet`, (): void => {
   beforeEach((): void => {
     dummyId = 'dummyId';
     dummyMessage = 'dummyMessage';
-    dummyTopicId = 'dummyTopicId';
+    dummySourceTopicId = 'dummySourceTopicId';
+    dummyTargetTopicId = 'dummyTargetTopicId';
     dummyUserId = 'dummyUserId';
     dummyState = 'open';
     dummyCreatedAt = 1540308640;
@@ -40,7 +42,8 @@ describe(`apiGet`, (): void => {
             state: dummyState,
           },
           relationships: {
-            topic: { data: { id: dummyTopicId } },
+            source: { data: { id: dummySourceTopicId } },
+            target: { data: { id: dummyTargetTopicId } },
             user: { data: { id: dummyUserId } },
           },
           meta: { createdAt: dummyCreatedAt },
@@ -53,7 +56,7 @@ describe(`apiGet`, (): void => {
         [call(api.pullRequests.get, dummyId), dummyApiResponse],
       ])
       .call(api.pullRequests.get, dummyId)
-      .put(actions.setMultipleInState([{ id: dummyId, message: dummyMessage, topicId: dummyTopicId, userId: dummyUserId, state: pullRequestStates.OPEN, timestamp: (dummyCreatedAt * 1000) }]))
+      .put(actions.setMultipleInState([{ id: dummyId, message: dummyMessage, sourceTopicId: dummySourceTopicId, targetTopicId: dummyTargetTopicId, userId: dummyUserId, state: pullRequestStates.OPEN, timestamp: (dummyCreatedAt * 1000) }]))
       .run();
   });
 

--- a/app/modules/pullRequests/saga/api/apiPost.js
+++ b/app/modules/pullRequests/saga/api/apiPost.js
@@ -1,0 +1,26 @@
+// @flow
+
+import { type Saga } from 'redux-saga';
+import { call, select } from 'redux-saga/effects';
+
+import api from 'api';
+import { UnexpectedHttpResponseError, UnsupportedOperationError } from 'errors';
+import { type ApiResponseData } from 'lib/ApiRequest';
+import platform from 'modules/platform';
+
+import * as a from '../../actionTypes';
+
+const apiPost = function* (action: a.ApiPostAction): Saga<{ id: string }> {
+  const { message, topicId, userId } = action.payload;
+  const userAuth: ?platform.model.UserAuth = yield select(platform.selectors.getUserAuth);
+  if (userAuth == null) throw new UnsupportedOperationError(`Not signed in.`);
+
+  const responseData: ApiResponseData = yield call(
+    api.pullRequests.post, message, topicId, userId, userAuth.apiToken,
+  );
+  if (responseData.body == null) throw new UnexpectedHttpResponseError();
+
+  return { id: responseData.body.data.id };
+};
+
+export default apiPost;

--- a/app/modules/pullRequests/saga/api/apiPost.js
+++ b/app/modules/pullRequests/saga/api/apiPost.js
@@ -11,12 +11,12 @@ import platform from 'modules/platform';
 import * as a from '../../actionTypes';
 
 const apiPost = function* (action: a.ApiPostAction): Saga<{ id: string }> {
-  const { message, topicId, userId } = action.payload;
+  const { message, sourceTopicId, targetTopicId, userId } = action.payload;
   const userAuth: ?platform.model.UserAuth = yield select(platform.selectors.getUserAuth);
   if (userAuth == null) throw new UnsupportedOperationError(`Not signed in.`);
 
   const responseData: ApiResponseData = yield call(
-    api.pullRequests.post, message, topicId, userId, userAuth.apiToken,
+    api.pullRequests.post, message, sourceTopicId, targetTopicId, userId, userAuth.apiToken,
   );
   if (responseData.body == null) throw new UnexpectedHttpResponseError();
 

--- a/app/modules/pullRequests/saga/api/apiPost.test.js
+++ b/app/modules/pullRequests/saga/api/apiPost.test.js
@@ -16,19 +16,21 @@ describe(`apiPost`, (): void => {
   let dummyId: string;
   let dummyToken: string;
   let dummyMessage: string;
-  let dummyTopicId: string;
+  let dummySourceTopicId: string;
+  let dummyTargetTopicId: string;
   let dummyUserId: string;
 
   beforeEach((): void => {
     dummyId = 'dummyId';
     dummyToken = 'dummyToken';
     dummyMessage = 'dummyMessage';
-    dummyTopicId = 'dummyTopicId';
+    dummySourceTopicId = 'dummySourceTopicId';
+    dummyTargetTopicId = 'dummyTargetTopicId';
     dummyUserId = 'dummyUserId';
   });
 
   it(`sends a POST request for the passed props to the pullRequests endpoint, and returns the resulting pull request identifier`, (): void => {
-    const dummyAction = actions.apiPost(dummyMessage, dummyTopicId, dummyUserId);
+    const dummyAction = actions.apiPost(dummyMessage, dummySourceTopicId, dummyTargetTopicId, dummyUserId);
     const dummyApiResponse = {
       status: 204,
       body: {
@@ -41,15 +43,15 @@ describe(`apiPost`, (): void => {
     return expectSaga(sagas.apiPost, dummyAction)
       .provide([
         [select(platform.selectors.getUserAuth), { userId: 'dummyUserId', apiToken: dummyToken }],
-        [call(api.pullRequests.post, dummyMessage, dummyTopicId, dummyUserId, dummyToken), dummyApiResponse],
+        [call(api.pullRequests.post, dummyMessage, dummySourceTopicId, dummyTargetTopicId, dummyUserId, dummyToken), dummyApiResponse],
       ])
-      .call(api.pullRequests.post, dummyMessage, dummyTopicId, dummyUserId, dummyToken)
+      .call(api.pullRequests.post, dummyMessage, dummySourceTopicId, dummyTargetTopicId, dummyUserId, dummyToken)
       .returns({ id: dummyId })
       .run();
   });
 
   it(`throws an UnsupportedOperationError, when there is no currently signed in user`, async (): Promise<mixed> => {
-    const dummyAction = actions.apiPost(dummyMessage, dummyTopicId, dummyUserId);
+    const dummyAction = actions.apiPost(dummyMessage, dummySourceTopicId, dummyTargetTopicId, dummyUserId);
     const dummyApiResponse = {
       status: 204,
       body: {
@@ -65,14 +67,14 @@ describe(`apiPost`, (): void => {
       expectSaga(sagas.apiPost, dummyAction)
         .provide([
           [select(platform.selectors.getUserAuth), null],
-          [call(api.pullRequests.post, dummyMessage, dummyTopicId, dummyUserId, dummyToken), dummyApiResponse],
+          [call(api.pullRequests.post, dummyMessage, dummySourceTopicId, dummyTargetTopicId, dummyUserId, dummyToken), dummyApiResponse],
         ])
         .run(),
     ).rejects.toBeInstanceOf(UnsupportedOperationError);
   });
 
   it(`throws an UnexpectedHttpResponseError, when the request response doesn't contain a body`, async (): Promise<mixed> => {
-    const dummyAction = actions.apiPost(dummyMessage, dummyTopicId, dummyUserId);
+    const dummyAction = actions.apiPost(dummyMessage, dummySourceTopicId, dummyTargetTopicId, dummyUserId);
     const dummyApiResponse = { status: 204 };
 
     // Suppress console.error from redux-saga $FlowFixMe
@@ -81,7 +83,7 @@ describe(`apiPost`, (): void => {
       expectSaga(sagas.apiPost, dummyAction)
         .provide([
           [select(platform.selectors.getUserAuth), { userId: 'dummyUserId', apiToken: dummyToken }],
-          [call(api.pullRequests.post, dummyMessage, dummyTopicId, dummyUserId, dummyToken), dummyApiResponse],
+          [call(api.pullRequests.post, dummyMessage, dummySourceTopicId, dummyTargetTopicId, dummyUserId, dummyToken), dummyApiResponse],
         ])
         .run(),
     ).rejects.toBeInstanceOf(UnexpectedHttpResponseError);

--- a/app/modules/pullRequests/saga/api/apiPost.test.js
+++ b/app/modules/pullRequests/saga/api/apiPost.test.js
@@ -1,0 +1,90 @@
+// @flow
+
+import { expectSaga } from 'redux-saga-test-plan';
+import { call, select } from 'redux-saga/effects';
+
+import api from 'api';
+import { UnexpectedHttpResponseError, UnsupportedOperationError } from 'errors';
+import platform from 'modules/platform';
+
+import actions from '../../actions';
+
+import { sagas } from '..';
+
+describe(`apiPost`, (): void => {
+
+  let dummyId: string;
+  let dummyToken: string;
+  let dummyMessage: string;
+  let dummyTopicId: string;
+  let dummyUserId: string;
+
+  beforeEach((): void => {
+    dummyId = 'dummyId';
+    dummyToken = 'dummyToken';
+    dummyMessage = 'dummyMessage';
+    dummyTopicId = 'dummyTopicId';
+    dummyUserId = 'dummyUserId';
+  });
+
+  it(`sends a POST request for the passed props to the pullRequests endpoint, and returns the resulting pull request identifier`, (): void => {
+    const dummyAction = actions.apiPost(dummyMessage, dummyTopicId, dummyUserId);
+    const dummyApiResponse = {
+      status: 204,
+      body: {
+        data: {
+          id: dummyId,
+        },
+      },
+    };
+
+    return expectSaga(sagas.apiPost, dummyAction)
+      .provide([
+        [select(platform.selectors.getUserAuth), { userId: 'dummyUserId', apiToken: dummyToken }],
+        [call(api.pullRequests.post, dummyMessage, dummyTopicId, dummyUserId, dummyToken), dummyApiResponse],
+      ])
+      .call(api.pullRequests.post, dummyMessage, dummyTopicId, dummyUserId, dummyToken)
+      .returns({ id: dummyId })
+      .run();
+  });
+
+  it(`throws an UnsupportedOperationError, when there is no currently signed in user`, async (): Promise<mixed> => {
+    const dummyAction = actions.apiPost(dummyMessage, dummyTopicId, dummyUserId);
+    const dummyApiResponse = {
+      status: 204,
+      body: {
+        data: {
+          id: dummyId,
+        },
+      },
+    };
+
+    // Suppress console.error from redux-saga $FlowFixMe
+    console.error = jest.fn();
+    await expect(
+      expectSaga(sagas.apiPost, dummyAction)
+        .provide([
+          [select(platform.selectors.getUserAuth), null],
+          [call(api.pullRequests.post, dummyMessage, dummyTopicId, dummyUserId, dummyToken), dummyApiResponse],
+        ])
+        .run(),
+    ).rejects.toBeInstanceOf(UnsupportedOperationError);
+  });
+
+  it(`throws an UnexpectedHttpResponseError, when the request response doesn't contain a body`, async (): Promise<mixed> => {
+    const dummyAction = actions.apiPost(dummyMessage, dummyTopicId, dummyUserId);
+    const dummyApiResponse = { status: 204 };
+
+    // Suppress console.error from redux-saga $FlowFixMe
+    console.error = jest.fn();
+    await expect(
+      expectSaga(sagas.apiPost, dummyAction)
+        .provide([
+          [select(platform.selectors.getUserAuth), { userId: 'dummyUserId', apiToken: dummyToken }],
+          [call(api.pullRequests.post, dummyMessage, dummyTopicId, dummyUserId, dummyToken), dummyApiResponse],
+        ])
+        .run(),
+    ).rejects.toBeInstanceOf(UnexpectedHttpResponseError);
+  });
+
+});

--- a/app/modules/pullRequests/saga/api/index.js
+++ b/app/modules/pullRequests/saga/api/index.js
@@ -1,0 +1,27 @@
+// @flow
+
+/* eslint-disable max-len, sort-imports */
+
+import { type Saga } from 'redux-saga';
+import { all, takeEvery } from 'redux-saga/effects';
+
+import asyncRequests from 'modules/asyncRequests';
+
+import * as a from '../../actionTypes';
+
+import apiGet from './apiGet';
+
+const { sagaWrapper } = asyncRequests.lib;
+
+const apiSaga = function* (): Saga<void> {
+  yield all([
+    takeEvery(a.API_GET, sagaWrapper, apiGet),
+  ]);
+};
+
+const apiSagas = {
+  apiGet,
+};
+
+export { apiSagas };
+export default apiSaga;

--- a/app/modules/pullRequests/saga/api/index.js
+++ b/app/modules/pullRequests/saga/api/index.js
@@ -10,17 +10,20 @@ import asyncRequests from 'modules/asyncRequests';
 import * as a from '../../actionTypes';
 
 import apiGet from './apiGet';
+import apiPost from './apiPost';
 
 const { sagaWrapper } = asyncRequests.lib;
 
 const apiSaga = function* (): Saga<void> {
   yield all([
     takeEvery(a.API_GET, sagaWrapper, apiGet),
+    takeEvery(a.API_POST, sagaWrapper, apiPost),
   ]);
 };
 
 const apiSagas = {
   apiGet,
+  apiPost,
 };
 
 export { apiSagas };

--- a/app/modules/pullRequests/saga/index.js
+++ b/app/modules/pullRequests/saga/index.js
@@ -1,0 +1,24 @@
+// @flow
+
+/* eslint-disable sort-imports */
+
+import { type Saga } from 'redux-saga';
+import { all, call } from 'redux-saga/effects';
+
+import apiSaga, { apiSagas } from './api';
+import taskSaga, { taskSagas } from './task';
+
+const saga = function* (): Saga<void> {
+  yield all([
+    call(apiSaga),
+    call(taskSaga),
+  ]);
+};
+
+const sagas = {
+  ...apiSagas,
+  ...taskSagas,
+};
+
+export { sagas };
+export default saga;

--- a/app/modules/pullRequests/saga/index.test.js
+++ b/app/modules/pullRequests/saga/index.test.js
@@ -1,0 +1,24 @@
+// @flow
+
+import { expectSaga } from 'redux-saga-test-plan';
+
+import apiSaga from './api';
+import taskSaga from './task';
+
+import saga from '.';
+
+describe(`saga`, (): void => {
+
+  it(`yields a call to apiSaga`, (): void => {
+    return expectSaga(saga)
+      .call(apiSaga)
+      .silentRun();
+  });
+
+  it(`yields a call to taskSaga`, (): void => {
+    return expectSaga(saga)
+      .call(taskSaga)
+      .silentRun();
+  });
+
+});

--- a/app/modules/pullRequests/saga/task/create.js
+++ b/app/modules/pullRequests/saga/task/create.js
@@ -10,7 +10,7 @@ import * as a from '../../actionTypes';
 
 const { putAndReturn } = asyncRequests.lib;
 
-const submit = function* (action: a.SubmitAction): Saga<{ id: string }> {
+const create = function* (action: a.CreateAction): Saga<{ id: string }> {
   const { message, sourceTopicId, targetTopicId, userId } = action.payload;
 
   // Create the new pull request in the backend.
@@ -25,4 +25,4 @@ const submit = function* (action: a.SubmitAction): Saga<{ id: string }> {
   return { id };
 };
 
-export default submit;
+export default create;

--- a/app/modules/pullRequests/saga/task/create.test.js
+++ b/app/modules/pullRequests/saga/task/create.test.js
@@ -28,9 +28,9 @@ describe(`create`, (): void => {
   });
 
   it(`puts a pullRequests apiPost action and returns the apiPost result`, (): void => {
-    const dummyAction = actions.submit(dummyMessage, dummySourceTopicId, dummyTargetTopicId, dummyUserId);
+    const dummyAction = actions.create(dummyMessage, dummySourceTopicId, dummyTargetTopicId, dummyUserId);
 
-    return expectSaga(sagas.submit, dummyAction)
+    return expectSaga(sagas.create, dummyAction)
       .provide([
         [matchers.call.fn(asyncRequests.lib.putAndReturn), dynamic(({ args: [action] }: any, next: any): any => {
           return (action.type === a.API_POST) ? { id: dummyId } : next();

--- a/app/modules/pullRequests/saga/task/fetch.js
+++ b/app/modules/pullRequests/saga/task/fetch.js
@@ -1,0 +1,18 @@
+// @flow
+
+import { type Saga } from 'redux-saga';
+import { call } from 'redux-saga/effects';
+
+import asyncRequests from 'modules/asyncRequests';
+
+import actions from '../../actions';
+import * as a from '../../actionTypes';
+
+const { putAndReturn } = asyncRequests.lib;
+
+const fetch = function* (action: a.FetchAction): Saga<void> {
+  const { id } = action.payload;
+  yield call(putAndReturn, actions.apiGet(id));
+};
+
+export default fetch;

--- a/app/modules/pullRequests/saga/task/fetch.test.js
+++ b/app/modules/pullRequests/saga/task/fetch.test.js
@@ -1,0 +1,35 @@
+// @flow
+
+import { expectSaga } from 'redux-saga-test-plan';
+import * as matchers from 'redux-saga-test-plan/matchers';
+import { dynamic } from 'redux-saga-test-plan/providers';
+
+import asyncRequests from 'modules/asyncRequests';
+
+import actions from '../../actions';
+import * as a from '../../actionTypes';
+
+import { sagas } from '..';
+
+describe(`fetch`, (): void => {
+
+  let dummyId: string;
+
+  beforeEach((): void => {
+    dummyId = 'dummyId';
+  });
+
+  it(`puts a pullRequests apiGet action and waits for the request to complete`, (): void => {
+    const dummyAction = actions.fetch(dummyId);
+
+    return expectSaga(sagas.fetch, dummyAction)
+      .provide([
+        [matchers.call.fn(asyncRequests.lib.putAndReturn), dynamic(({ args: [action] }: any, next: any): any => {
+          return (action.type === a.API_GET) ? null : next();
+        })],
+      ])
+      .call(asyncRequests.lib.putAndReturn, actions.apiGet(dummyId))
+      .run();
+  });
+
+});

--- a/app/modules/pullRequests/saga/task/index.js
+++ b/app/modules/pullRequests/saga/task/index.js
@@ -10,6 +10,7 @@ import asyncRequests from 'modules/asyncRequests';
 import * as a from '../../actionTypes';
 
 import fetch from './fetch';
+import submit from './submit';
 
 const { sagaWrapper } = asyncRequests.lib;
 
@@ -21,6 +22,7 @@ const taskSaga = function* (): Saga<void> {
 
 const taskSagas = {
   fetch,
+  submit,
 };
 
 export { taskSagas };

--- a/app/modules/pullRequests/saga/task/index.js
+++ b/app/modules/pullRequests/saga/task/index.js
@@ -1,0 +1,27 @@
+// @flow
+
+/* eslint-disable max-len, sort-imports */
+
+import { type Saga } from 'redux-saga';
+import { all, takeEvery } from 'redux-saga/effects';
+
+import asyncRequests from 'modules/asyncRequests';
+
+import * as a from '../../actionTypes';
+
+import fetch from './fetch';
+
+const { sagaWrapper } = asyncRequests.lib;
+
+const taskSaga = function* (): Saga<void> {
+  yield all([
+    takeEvery(a.FETCH, sagaWrapper, fetch),
+  ]);
+};
+
+const taskSagas = {
+  fetch,
+};
+
+export { taskSagas };
+export default taskSaga;

--- a/app/modules/pullRequests/saga/task/index.js
+++ b/app/modules/pullRequests/saga/task/index.js
@@ -9,20 +9,21 @@ import asyncRequests from 'modules/asyncRequests';
 
 import * as a from '../../actionTypes';
 
+import create from './create';
 import fetch from './fetch';
-import submit from './submit';
 
 const { sagaWrapper } = asyncRequests.lib;
 
 const taskSaga = function* (): Saga<void> {
   yield all([
+    takeEvery(a.CREATE, sagaWrapper, create),
     takeEvery(a.FETCH, sagaWrapper, fetch),
   ]);
 };
 
 const taskSagas = {
+  create,
   fetch,
-  submit,
 };
 
 export { taskSagas };

--- a/app/modules/pullRequests/saga/task/submit.js
+++ b/app/modules/pullRequests/saga/task/submit.js
@@ -17,6 +17,9 @@ const submit = function* (action: a.SubmitAction): Saga<{ id: string }> {
   const { id } = yield call(putAndReturn, actions.apiPost(
     message, sourceTopicId, targetTopicId, userId,
   ));
+  // Fetch the new topic from the backend so the state is up-to-date,
+  // and wait for request completion.
+  yield call(putAndReturn, actions.fetch(id));
 
   // Return the pull request id.
   return { id };

--- a/app/modules/pullRequests/saga/task/submit.js
+++ b/app/modules/pullRequests/saga/task/submit.js
@@ -1,0 +1,25 @@
+// @flow
+
+import { type Saga } from 'redux-saga';
+import { call } from 'redux-saga/effects';
+
+import asyncRequests from 'modules/asyncRequests';
+
+import actions from '../../actions';
+import * as a from '../../actionTypes';
+
+const { putAndReturn } = asyncRequests.lib;
+
+const submit = function* (action: a.SubmitAction): Saga<{ id: string }> {
+  const { message, topicId, userId } = action.payload;
+
+  // Create the new pull request in the backend.
+  const { id } = yield call(putAndReturn, actions.apiPost(
+    message, topicId, userId,
+  ));
+
+  // Return the pull request id.
+  return { id };
+};
+
+export default submit;

--- a/app/modules/pullRequests/saga/task/submit.js
+++ b/app/modules/pullRequests/saga/task/submit.js
@@ -11,11 +11,11 @@ import * as a from '../../actionTypes';
 const { putAndReturn } = asyncRequests.lib;
 
 const submit = function* (action: a.SubmitAction): Saga<{ id: string }> {
-  const { message, topicId, userId } = action.payload;
+  const { message, sourceTopicId, targetTopicId, userId } = action.payload;
 
   // Create the new pull request in the backend.
   const { id } = yield call(putAndReturn, actions.apiPost(
-    message, topicId, userId,
+    message, sourceTopicId, targetTopicId, userId,
   ));
 
   // Return the pull request id.

--- a/app/modules/pullRequests/saga/task/submit.test.js
+++ b/app/modules/pullRequests/saga/task/submit.test.js
@@ -15,18 +15,20 @@ describe(`create`, (): void => {
 
   let dummyId: string;
   let dummyMessage: string;
-  let dummyTopicId: string;
+  let dummySourceTopicId: string;
+  let dummyTargetTopicId: string;
   let dummyUserId: string;
 
   beforeEach((): void => {
     dummyId = 'dummyId';
     dummyMessage = 'dummyMessage';
-    dummyTopicId = 'Lorem ipsum dolor sit amet.';
+    dummySourceTopicId = 'dummySourceTopicId';
+    dummyTargetTopicId = 'dummyTargetTopicId';
     dummyUserId = 'dummyUserId';
   });
 
   it(`puts a pullRequests apiPost action and returns the apiPost result`, (): void => {
-    const dummyAction = actions.submit(dummyMessage, dummyTopicId, dummyUserId);
+    const dummyAction = actions.submit(dummyMessage, dummySourceTopicId, dummyTargetTopicId, dummyUserId);
 
     return expectSaga(sagas.submit, dummyAction)
       .provide([
@@ -34,7 +36,7 @@ describe(`create`, (): void => {
           return (action.type === a.API_POST) ? { id: dummyId } : next();
         })],
       ])
-      .call(asyncRequests.lib.putAndReturn, actions.apiPost(dummyMessage, dummyTopicId, dummyUserId))
+      .call(asyncRequests.lib.putAndReturn, actions.apiPost(dummyMessage, dummySourceTopicId, dummyTargetTopicId, dummyUserId))
       .returns({ id: dummyId })
       .run();
   });

--- a/app/modules/pullRequests/saga/task/submit.test.js
+++ b/app/modules/pullRequests/saga/task/submit.test.js
@@ -35,8 +35,12 @@ describe(`create`, (): void => {
         [matchers.call.fn(asyncRequests.lib.putAndReturn), dynamic(({ args: [action] }: any, next: any): any => {
           return (action.type === a.API_POST) ? { id: dummyId } : next();
         })],
+        [matchers.call.fn(asyncRequests.lib.putAndReturn), dynamic(({ args: [action] }: any, next: any): any => {
+          return (action.type === a.FETCH) ? null : next();
+        })],
       ])
       .call(asyncRequests.lib.putAndReturn, actions.apiPost(dummyMessage, dummySourceTopicId, dummyTargetTopicId, dummyUserId))
+      .call(asyncRequests.lib.putAndReturn, actions.fetch(dummyId))
       .returns({ id: dummyId })
       .run();
   });

--- a/app/modules/pullRequests/saga/task/submit.test.js
+++ b/app/modules/pullRequests/saga/task/submit.test.js
@@ -1,0 +1,42 @@
+// @flow
+
+import { expectSaga } from 'redux-saga-test-plan';
+import * as matchers from 'redux-saga-test-plan/matchers';
+import { dynamic } from 'redux-saga-test-plan/providers';
+
+import asyncRequests from 'modules/asyncRequests';
+
+import actions from '../../actions';
+import * as a from '../../actionTypes';
+
+import { sagas } from '..';
+
+describe(`create`, (): void => {
+
+  let dummyId: string;
+  let dummyMessage: string;
+  let dummyTopicId: string;
+  let dummyUserId: string;
+
+  beforeEach((): void => {
+    dummyId = 'dummyId';
+    dummyMessage = 'dummyMessage';
+    dummyTopicId = 'Lorem ipsum dolor sit amet.';
+    dummyUserId = 'dummyUserId';
+  });
+
+  it(`puts a pullRequests apiPost action and returns the apiPost result`, (): void => {
+    const dummyAction = actions.submit(dummyMessage, dummyTopicId, dummyUserId);
+
+    return expectSaga(sagas.submit, dummyAction)
+      .provide([
+        [matchers.call.fn(asyncRequests.lib.putAndReturn), dynamic(({ args: [action] }: any, next: any): any => {
+          return (action.type === a.API_POST) ? { id: dummyId } : next();
+        })],
+      ])
+      .call(asyncRequests.lib.putAndReturn, actions.apiPost(dummyMessage, dummyTopicId, dummyUserId))
+      .returns({ id: dummyId })
+      .run();
+  });
+
+});

--- a/app/modules/pullRequests/selectors/getById.js
+++ b/app/modules/pullRequests/selectors/getById.js
@@ -1,0 +1,12 @@
+// @flow
+
+import { type AppState } from 'types/redux';
+
+import * as m from '../model';
+
+const getById = (state: AppState, props: { id: string }): ?m.PullRequest => {
+  const { id } = props;
+  return state.modules.pullRequests.byId[id] || null;
+};
+
+export default getById;

--- a/app/modules/pullRequests/selectors/getById.test.js
+++ b/app/modules/pullRequests/selectors/getById.test.js
@@ -1,0 +1,38 @@
+// @flow
+
+import { dummyPullRequestData } from 'lib/testResources';
+
+import * as m from '../model';
+
+import selectors from '.';
+
+describe(`getById`, (): void => {
+
+  let dummyPullRequest1: m.PullRequest;
+  let dummyPullRequest2: m.PullRequest;
+  let dummyPullRequestsById: m.PullRequestsById;
+  let dummyPullRequestsState: m.PullRequestsState;
+  let dummyState: any;
+
+  beforeEach((): void => {
+    dummyPullRequest1 = { ...dummyPullRequestData.pullRequest };
+    dummyPullRequest2 = { ...dummyPullRequestData.pullRequest2 };
+    dummyPullRequestsById = {
+      [dummyPullRequest1.id]: dummyPullRequest1,
+      [dummyPullRequest2.id]: dummyPullRequest2,
+    };
+    dummyPullRequestsState = { byId: dummyPullRequestsById };
+    dummyState = { modules: { pullRequests: dummyPullRequestsState } };
+  });
+
+  it(`returns the correct pullRequest for the given id, when the given id is valid`, (): void => {
+    const pullRequest = selectors.getById(dummyState, { id: dummyPullRequest1.id });
+    expect(pullRequest).toBe(dummyPullRequest1);
+  });
+
+  it(`returns NULL, when the given id is invalid`, (): void => {
+    const pullRequest = selectors.getById(dummyState, { id: 'InvalidId' });
+    expect(pullRequest).toBeNull();
+  });
+
+});

--- a/app/modules/pullRequests/selectors/index.js
+++ b/app/modules/pullRequests/selectors/index.js
@@ -1,0 +1,9 @@
+// @flow
+
+import getById from './getById';
+
+const selectors = {
+  getById,
+};
+
+export default selectors;

--- a/app/store/modulesReducer.js
+++ b/app/store/modulesReducer.js
@@ -9,6 +9,7 @@ import contentItems from 'modules/contentItems';
 import errors from 'modules/errors';
 import feedItems from 'modules/feedItems';
 import platform from 'modules/platform';
+import pullRequests from 'modules/pullRequests';
 import topics from 'modules/topics';
 import users from 'modules/users';
 
@@ -19,6 +20,7 @@ const modulesReducer = combineReducers({
   errors: errors.reducer,
   feedItems: feedItems.reducer,
   platform: platform.reducer,
+  pullRequests: pullRequests.reducer,
   topics: topics.reducer,
   users: users.reducer,
 });

--- a/app/store/rootSaga.js
+++ b/app/store/rootSaga.js
@@ -10,6 +10,7 @@ import contentItems from 'modules/contentItems';
 import errors from 'modules/errors';
 import feedItems from 'modules/feedItems';
 import platform from 'modules/platform';
+import pullRequests from 'modules/pullRequests';
 import topics from 'modules/topics';
 import users from 'modules/users';
 
@@ -24,6 +25,7 @@ const rootSaga = function* (): Saga<void> {
     call(errors.saga),
     call(feedItems.saga),
     call(platform.saga),
+    call(pullRequests.saga),
     call(topics.saga),
     call(users.saga),
   ]);

--- a/app/types/redux.js
+++ b/app/types/redux.js
@@ -17,6 +17,9 @@ import { type FeedItemsState } from 'modules/feedItems/model';
 // Platform module
 import { type PlatformAction } from 'modules/platform/actionTypes';
 import { type PlatformState } from 'modules/platform/model';
+// PullRequests module
+import { type PullRequestsAction } from 'modules/pullRequests/actionTypes';
+import { type PullRequestsState } from 'modules/pullRequests/model';
 // Topics module
 import { type TopicsAction } from 'modules/topics/actionTypes';
 import { type TopicsState } from 'modules/topics/model';
@@ -30,6 +33,7 @@ export type ModulesAction =
   | ErrorsAction
   | FeedItemsAction
   | PlatformAction
+  | PullRequestsAction
   | TopicsAction
   | UsersAction;
 
@@ -39,6 +43,7 @@ export type ModulesState = {|
   +errors: ErrorsState,
   +feedItems: FeedItemsState,
   +platform: PlatformState,
+  +pullRequests: PullRequestsState,
   +topics: TopicsState,
   +users: UsersState,
 |};


### PR DESCRIPTION
Add a `pullRequests` module, containing the following functionality:
- Saga and relevant API code to fetch a pull request
- Saga and relevant API code to submit a pull request **(note: selecting/cherry-picking commit has been deferred until further notice)**

The API server has currently not implemented the Pull Requests API yet, nor is there documentation available.

This PR is made in preparation of the [Make pull request](https://trello.com/c/kPVAJqkW/108-make-pull-request) backlog item.