### PR TITLE
Allow authenticated topics apiGet calls

### DIFF
--- a/app/api/topics/get.js
+++ b/app/api/topics/get.js
@@ -10,11 +10,12 @@ import ApiRequest, { httpMethods, type ApiResponseData } from 'lib/ApiRequest';
 
 import { TOPICS_ENDPOINT } from '../endpoints';
 
-const get = (id: string): Promise<ApiResponseData> => {
+const get = (id: string, token: ?string): Promise<ApiResponseData> => {
   return new ApiRequest(httpMethods.GET)
     .addPathSegment(TOPICS_ENDPOINT)
     .addPathSegment(id)
     .setParameter('include', 'upstream,forks')
+    .setToken(token)
     .execute();
 };
 

--- a/app/api/topics/get.test.js
+++ b/app/api/topics/get.test.js
@@ -7,14 +7,19 @@ import api from '..';
 
 describe(`api.topics.get`, (): void => {
 
+  let dummyTopicId: string;
+  let dummyToken: string;
+
   beforeEach((): void => {
     fetch.resetMocks();
+
+    dummyTopicId = 'dummyTopicId';
+    dummyToken = 'dummyToken';
   });
 
   it(`executes the correct fetch call`, async (): Promise<mixed> => {
-    const dummyTopicId = 'ThisIsAnId';
     fetch.mockResponseOnce('', { status: 200 });
-    await api.topics.get(dummyTopicId);
+    await api.topics.get(dummyTopicId, dummyToken);
 
     expect(fetch.mock.calls).toHaveLength(1);
 
@@ -24,6 +29,7 @@ describe(`api.topics.get`, (): void => {
     expect(mockUrl).toBe(`${API_URL}/topics/${dummyTopicId}?include=upstream${encodeURIComponent(',')}forks`);
     expect(mockOptions.method).toBe(httpMethods.GET);
     expect(mockOptions.body).toBeNull();
+    expect(mockOptions.headers.Authorization).toBe(`Bearer ${dummyToken}`);
   });
 
 });

--- a/app/modules/topics/saga/api/apiGet.js
+++ b/app/modules/topics/saga/api/apiGet.js
@@ -1,11 +1,12 @@
 // @flow
 
 import { type Saga } from 'redux-saga';
-import { call, put } from 'redux-saga/effects';
+import { call, put, select } from 'redux-saga/effects';
 
 import api from 'api';
 import { UnexpectedHttpResponseError } from 'errors';
 import { type ApiResponseData } from 'lib/ApiRequest';
+import platform from 'modules/platform';
 
 import actions from '../../actions';
 import * as a from '../../actionTypes';
@@ -13,7 +14,10 @@ import * as m from '../../model';
 
 const apiGet = function* (action: a.ApiGetAction): Saga<void> {
   const { id } = action.payload;
-  const topicsResponseData: ApiResponseData = yield call(api.topics.get, id);
+  const userAuth: ?platform.model.UserAuth = yield select(platform.selectors.getUserAuth);
+  const apiToken = (userAuth != null) ? userAuth.apiToken : null;
+
+  const topicsResponseData: ApiResponseData = yield call(api.topics.get, id, apiToken);
   if (topicsResponseData.body == null) {
     throw new UnexpectedHttpResponseError();
   }


### PR DESCRIPTION
Add a `token` argument to topics `apiGet` saga. Fixes #185.