### PR TITLE
Allow authenticated api.topics.getContent and .getAllByUserId calls

### DIFF
--- a/app/api/topics/get.test.js
+++ b/app/api/topics/get.test.js
@@ -32,4 +32,19 @@ describe(`api.topics.get`, (): void => {
     expect(mockOptions.headers.Authorization).toBe(`Bearer ${dummyToken}`);
   });
 
+  it(`omits token when the corresponding parameter is passed as NULL`, async (): Promise<mixed> => {
+    fetch.mockResponseOnce('', { status: 200 });
+    await api.topics.get(dummyTopicId, null);
+
+    expect(fetch.mock.calls).toHaveLength(1);
+
+    const mockUrl = fetch.mock.calls[0][0];
+    const mockOptions = fetch.mock.calls[0][1];
+
+    expect(mockUrl).toBe(`${API_URL}/topics/${dummyTopicId}?include=upstream${encodeURIComponent(',')}forks`);
+    expect(mockOptions.method).toBe(httpMethods.GET);
+    expect(mockOptions.body).toBeNull();
+    expect(mockOptions.headers.Authorization).toBeUndefined();
+  });
+
 });

--- a/app/api/topics/getAllByUserId.js
+++ b/app/api/topics/getAllByUserId.js
@@ -10,11 +10,12 @@ import ApiRequest, { httpMethods, type ApiResponseData } from 'lib/ApiRequest';
 
 import { USERS_ENDPOINT, TOPICS_ENDPOINT } from '../endpoints';
 
-const getAllByUserId = (userId: string): Promise<ApiResponseData> => {
+const getAllByUserId = (userId: string, token: ?string): Promise<ApiResponseData> => {
   return new ApiRequest(httpMethods.GET)
     .addPathSegment(USERS_ENDPOINT)
     .addPathSegment(userId)
     .addPathSegment(TOPICS_ENDPOINT)
+    .setToken(token)
     .execute();
 };
 

--- a/app/api/topics/getAllByUserId.test.js
+++ b/app/api/topics/getAllByUserId.test.js
@@ -7,14 +7,19 @@ import api from '..';
 
 describe(`api.topics.getAllByUserId`, (): void => {
 
+  let dummyUserId: string;
+  let dummyToken: string;
+
   beforeEach((): void => {
     fetch.resetMocks();
+
+    dummyUserId = 'dummyUserId';
+    dummyToken = 'dummyToken';
   });
 
   it(`executes the correct fetch call`, async (): Promise<mixed> => {
-    const dummyUserId = 'ThisIsAnId';
     fetch.mockResponseOnce('', { status: 200 });
-    await api.topics.getAllByUserId(dummyUserId);
+    await api.topics.getAllByUserId(dummyUserId, dummyToken);
 
     expect(fetch.mock.calls).toHaveLength(1);
 
@@ -24,6 +29,22 @@ describe(`api.topics.getAllByUserId`, (): void => {
     expect(mockUrl).toBe(`${API_URL}/users/${dummyUserId}/topics`);
     expect(mockOptions.method).toBe(httpMethods.GET);
     expect(mockOptions.body).toBeNull();
+    expect(mockOptions.headers.Authorization).toBe(`Bearer ${dummyToken}`);
+  });
+
+  it(`omits token when the corresponding parameter is passed as NULL`, async (): Promise<mixed> => {
+    fetch.mockResponseOnce('', { status: 200 });
+    await api.topics.getAllByUserId(dummyUserId, null);
+
+    expect(fetch.mock.calls).toHaveLength(1);
+
+    const mockUrl = fetch.mock.calls[0][0];
+    const mockOptions = fetch.mock.calls[0][1];
+
+    expect(mockUrl).toBe(`${API_URL}/users/${dummyUserId}/topics`);
+    expect(mockOptions.method).toBe(httpMethods.GET);
+    expect(mockOptions.body).toBeNull();
+    expect(mockOptions.headers.Authorization).toBeUndefined();
   });
 
 });

--- a/app/api/topics/getContent.js
+++ b/app/api/topics/getContent.js
@@ -10,11 +10,12 @@ import ApiRequest, { httpMethods, type ApiResponseData } from 'lib/ApiRequest';
 
 import { TOPICS_ENDPOINT, TOPICS_CONTENT_ENDPOINT } from '../endpoints';
 
-const getContent = (topicId: string): Promise<ApiResponseData> => {
+const getContent = (id: string, token: ?string): Promise<ApiResponseData> => {
   return new ApiRequest(httpMethods.GET)
     .addPathSegment(TOPICS_ENDPOINT)
-    .addPathSegment(topicId)
+    .addPathSegment(id)
     .addPathSegment(TOPICS_CONTENT_ENDPOINT)
+    .setToken(token)
     .execute();
 };
 

--- a/app/api/topics/getContent.test.js
+++ b/app/api/topics/getContent.test.js
@@ -7,14 +7,19 @@ import api from '..';
 
 describe(`api.topics.getContent`, (): void => {
 
+  let dummyTopicId: string;
+  let dummyToken: string;
+
   beforeEach((): void => {
     fetch.resetMocks();
+
+    dummyTopicId = 'dummyTopicId';
+    dummyToken = 'dummyToken';
   });
 
   it(`executes the correct fetch call`, async (): Promise<mixed> => {
-    const dummyTopicId = 'ThisIsAnId';
     fetch.mockResponseOnce('', { status: 200 });
-    await api.topics.getContent(dummyTopicId);
+    await api.topics.getContent(dummyTopicId, dummyToken);
 
     expect(fetch.mock.calls).toHaveLength(1);
 
@@ -24,6 +29,22 @@ describe(`api.topics.getContent`, (): void => {
     expect(mockUrl).toBe(`${API_URL}/topics/${dummyTopicId}/content`);
     expect(mockOptions.method).toBe(httpMethods.GET);
     expect(mockOptions.body).toBeNull();
+    expect(mockOptions.headers.Authorization).toBe(`Bearer ${dummyToken}`);
+  });
+
+  it(`omits token when the corresponding parameter is passed as NULL`, async (): Promise<mixed> => {
+    fetch.mockResponseOnce('', { status: 200 });
+    await api.topics.getContent(dummyTopicId, null);
+
+    expect(fetch.mock.calls).toHaveLength(1);
+
+    const mockUrl = fetch.mock.calls[0][0];
+    const mockOptions = fetch.mock.calls[0][1];
+
+    expect(mockUrl).toBe(`${API_URL}/topics/${dummyTopicId}/content`);
+    expect(mockOptions.method).toBe(httpMethods.GET);
+    expect(mockOptions.body).toBeNull();
+    expect(mockOptions.headers.Authorization).toBeUndefined();
   });
 
 });

--- a/app/modules/contentItems/saga/api/apiGetAllByTopicId.js
+++ b/app/modules/contentItems/saga/api/apiGetAllByTopicId.js
@@ -1,11 +1,12 @@
 // @flow
 
 import { type Saga } from 'redux-saga';
-import { call, put } from 'redux-saga/effects';
+import { call, put, select } from 'redux-saga/effects';
 
 import { UnexpectedHttpResponseError } from 'errors';
 import api from 'api';
 import { type ApiResponseData } from 'lib/ApiRequest';
+import platform from 'modules/platform';
 
 import actions from '../../actions';
 import * as a from '../../actionTypes';
@@ -13,8 +14,10 @@ import * as m from '../../model';
 
 const apiGetAllByTopicId = function* (action: a.ApiGetAllByTopicIdAction): Saga<void> {
   const { topicId } = action.payload;
+  const userAuth: ?platform.model.UserAuth = yield select(platform.selectors.getUserAuth);
+  const apiToken = (userAuth != null) ? userAuth.apiToken : null;
 
-  const responseData: ApiResponseData = yield call(api.topics.getContent, topicId);
+  const responseData: ApiResponseData = yield call(api.topics.getContent, topicId, apiToken);
   if (responseData.body == null) throw new UnexpectedHttpResponseError();
   const { attributes } = responseData.body.data;
 


### PR DESCRIPTION
Same bug as #186, but this time the `getContent` and `getAllByUserId` are also included.

This closes #185 (again).