### PR TITLE
Fix missing eslint check for class properties

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,7 @@
+const { rules: airbnbBaseErrorsRules } = require('eslint-config-airbnb-base/rules/errors');
+const { rules: airbnbBaseStyleRules } = require('eslint-config-airbnb-base/rules/style');
+const { rules: airbnbBaseBestPracticeRules } = require('eslint-config-airbnb-base/rules/best-practices');
+
 module.exports = {
   'extends': [
     'airbnb',
@@ -13,6 +17,8 @@ module.exports = {
     'jest': true,
   },
   'plugins': [
+    // ESLint checking for experimental features enabled using babel.
+    'babel',
     // ESLint checking for Flow.
     'flowtype',
     // ESLint checking for Jest tests.
@@ -122,6 +128,15 @@ module.exports = {
         'allowTemplateLiterals': true,
       },
     ],
+
+    // Apply these eslint rules to the experimental JS features enabled by babel
+    'babel/new-cap': airbnbBaseStyleRules['new-cap'],
+    'babel/no-invalid-this': airbnbBaseBestPracticeRules['no-invalid-this'],
+    'babel/object-curly-spacing': airbnbBaseStyleRules['object-curly-spacing'],
+    'babel/quotes': ['error', 'single', { 'allowTemplateLiterals': true } ], // Use same override as for 'quotes' rule above
+    'babel/semi': airbnbBaseStyleRules['semi'],
+    // 'babel/no-unused-expressions': airbnbBaseBestPracticeRules['no-unused-expressions'], // conflicts with flowtype/no-unused-expressions
+    'babel/valid-typeof': airbnbBaseErrorsRules['valid-typeof'],
 
     // Enforce consistency in using array types.
     'flowtype/array-style-complex-type': 'error',

--- a/app/forms/EmailAndPasswordForm/index.js
+++ b/app/forms/EmailAndPasswordForm/index.js
@@ -36,7 +36,7 @@ class PureEmailAndPasswordForm extends React.Component<Props> {
     }
 
     return { ...errors };
-  }
+  };
 
   render(): React.Node {
     const { t, onSubmit, children } = this.props;

--- a/app/forms/EmailForm/index.js
+++ b/app/forms/EmailForm/index.js
@@ -31,7 +31,7 @@ class PureEmailForm extends React.Component<Props> {
     }
 
     return { ...errors };
-  }
+  };
 
   render(): React.Node {
     const { t, onSubmit, children } = this.props;

--- a/app/forms/ResetPasswordForm/index.js
+++ b/app/forms/ResetPasswordForm/index.js
@@ -42,7 +42,7 @@ class PureResetPasswordForm extends React.Component<Props> {
     }
 
     return { ...errors };
-  }
+  };
 
   render(): React.Node {
     const { t, onSubmit, children, resetPasswordToken } = this.props;

--- a/app/forms/TopicForm/index.js
+++ b/app/forms/TopicForm/index.js
@@ -36,7 +36,7 @@ class PureTopicForm extends React.Component<Props> {
     }
 
     return { ...errors };
-  }
+  };
 
   render(): React.Node {
     const { t, onSubmit, children } = this.props;

--- a/app/forms/UserForm/index.js
+++ b/app/forms/UserForm/index.js
@@ -51,7 +51,7 @@ class PureUserForm extends React.Component<Props> {
     }
 
     return { ...errors };
-  }
+  };
 
   render(): React.Node {
     const { t, onSubmit, children } = this.props;

--- a/app/modules/topics/components/Editor/index.js
+++ b/app/modules/topics/components/Editor/index.js
@@ -81,7 +81,7 @@ class PureEditor extends React.Component<Props> {
     }
 
     return topic.isDirty;
-  }
+  };
 
   componentDidMount = (): void => {
     // Add event listener to prevent unloading window when topic is dirty

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint": "^5.8.0",
     "eslint-config-airbnb": "^17.0.0",
     "eslint-import-resolver-webpack": "^0.10.1",
+    "eslint-plugin-babel": "^5.2.1",
     "eslint-plugin-flowtype": "^3.1.1",
     "eslint-plugin-import": "^2.13.0",
     "eslint-plugin-jest": "^21.26.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3183,6 +3183,12 @@ eslint-module-utils@^2.2.0:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
 
+eslint-plugin-babel@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-babel/-/eslint-plugin-babel-5.2.1.tgz#95cccad9a70908ab1d21276e7e33cc9701a18293"
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
 eslint-plugin-flowtype@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.1.1.tgz#1b96559b8015c06e6b7a3c5ba9c73d8e652e69d8"
@@ -3242,6 +3248,10 @@ eslint-plugin-redux-saga@^0.9.0:
 eslint-restricted-globals@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz#35f0d5cbc64c2e3ed62e93b4b1a7af05ba7ed4d7"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
 
 eslint-scope@3.7.1:
   version "3.7.1"


### PR DESCRIPTION
Added eslint-plugin-babel to enable checking for experimental JS features which have been enabled by babel; fixed newly detected errors.