### PR TITLE
Rename feedItem eventType to feedItemType

### DIFF
--- a/app/config/api.js
+++ b/app/config/api.js
@@ -41,4 +41,4 @@ export const API_URL = window.API_URL || 'http://owsdev.ugent.be/api';
  *  In most cases, specifying the ~> operator, and a major and minor versions should be adequate.
  *
  */
-export const API_VERSION = '~>9';
+export const API_VERSION = '~>10';

--- a/app/modules/feedItems/saga/api/apiGetAll.js
+++ b/app/modules/feedItems/saga/api/apiGetAll.js
@@ -11,7 +11,7 @@ import actions from '../../actions';
 import * as a from '../../actionTypes';
 import * as m from '../../model';
 
-const apiEventTypesToFeedItemTypesMap = {
+const apiFeedItemTypesToFeedItemTypesMap = {
   topic_created: m.feedItemTypes.CREATE,
   topic_updated: m.feedItemTypes.UPDATE,
   topic_forked: m.feedItemTypes.FORK,
@@ -27,12 +27,12 @@ const apiGetAll = function* (action: a.ApiGetAllAction): Saga<void> {
       id: item.id,
       userId: item.relationships.user.data.id,
       topicId: item.relationships.topic.data.id,
-      type: apiEventTypesToFeedItemTypesMap[item.attributes.eventType],
+      type: apiFeedItemTypesToFeedItemTypesMap[item.attributes.feedItemType],
       timestamp: Number(item.meta.createdAt) * 1000,
     };
   });
   yield put(actions.setMultipleInState(data));
 };
 
-export { apiEventTypesToFeedItemTypesMap };
+export { apiFeedItemTypesToFeedItemTypesMap };
 export default apiGetAll;

--- a/app/modules/feedItems/saga/api/apiGetAll.test.js
+++ b/app/modules/feedItems/saga/api/apiGetAll.test.js
@@ -11,7 +11,7 @@ import { dummyFeedItemData } from 'lib/testResources';
 import actions from '../../actions';
 import * as m from '../../model';
 
-import { apiEventTypesToFeedItemTypesMap } from './apiGetAll';
+import { apiFeedItemTypesToFeedItemTypesMap } from './apiGetAll';
 
 import { sagas } from '..';
 
@@ -33,7 +33,7 @@ describe(`apiGetAll`, (): void => {
         data: [
           {
             id: dummyFeedItem1.id,
-            attributes: { eventType: _.findKey(apiEventTypesToFeedItemTypesMap, (feedItemType: string): boolean => feedItemType === dummyFeedItem1.type) },
+            attributes: { feedItemType: _.findKey(apiFeedItemTypesToFeedItemTypesMap, (feedItemType: string): boolean => feedItemType === dummyFeedItem1.type) },
             relationships: {
               user: { data: { id: dummyFeedItem1.userId } },
               topic: { data: { id: dummyFeedItem1.topicId } },
@@ -42,7 +42,7 @@ describe(`apiGetAll`, (): void => {
           },
           {
             id: dummyFeedItem2.id,
-            attributes: { eventType: _.findKey(apiEventTypesToFeedItemTypesMap, (feedItemType: string): boolean => feedItemType === dummyFeedItem2.type) },
+            attributes: { feedItemType: _.findKey(apiFeedItemTypesToFeedItemTypesMap, (feedItemType: string): boolean => feedItemType === dummyFeedItem2.type) },
             relationships: {
               user: { data: { id: dummyFeedItem2.userId } },
               topic: { data: { id: dummyFeedItem2.topicId } },


### PR DESCRIPTION
:warning: Merge PR #201 first.

Rename feedItem `eventType` to `feedItemType` in API parser.

[Documentation](https://openwebslides.github.io/documentation/#api-v10)
[Trello](https://trello.com/c/iX1mPK5F/152-rename-feeditem-eventtype-into-feeditemtype)