### PR TITLE
Fix API_URL manual setup

### DIFF
--- a/app/config/api.js
+++ b/app/config/api.js
@@ -8,7 +8,7 @@
  * production runtime with the correct base URL configured for that server.
  * In development, it is also possible to use the API_URL environment variable.
  *
- * $ API_URL=http://localhost:3000/api yarn run dev-server
+ * $ yarn run dev-server --env.API_URL=http://localhost:3000/api
  *
  */
 export const API_URL = window.API_URL || 'http://owsdev.ugent.be/api';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,7 @@ const paths = {
 };
 
 // Webpack base configuration
-const baseConfig = {
+const createBaseConfig = (/* env */) => ({
 
   entry: ['@babel/polyfill', path.join(paths.APP, 'index.js')],
 
@@ -107,10 +107,10 @@ const baseConfig = {
     },
   },
 
-};
+});
 
 // Webpack developemnt mode additional configuration
-const devConfig = {
+const createDevConfig = (env) => ({
 
   devServer: {
     // Enable hot reloading
@@ -122,7 +122,7 @@ const devConfig = {
     new webpack.HotModuleReplacementPlugin(),
     // Allow specifying an API_URL override on the command line
     new webpack.DefinePlugin({
-      'window.API_URL': process.env.API_URL ? `"${process.env.API_URL}"` : false,
+      'window.API_URL': (env != null && env.API_URL != null) ? `"${env.API_URL}"` : false,
     }),
     new HtmlWebpackPlugin({
       template: path.join(paths.PUBLIC, 'index.dev.html'),
@@ -143,10 +143,10 @@ const devConfig = {
     ],
   },
 
-};
+});
 
 // Webpack production mode additional configuration
-const prodConfig = {
+const createProdConfig = (/* env */) => ({
 
   optimization: {
     minimizer: [
@@ -193,13 +193,13 @@ const prodConfig = {
     ],
   },
 
-};
+});
 
 module.exports = (env, argv) => {
   if (argv.mode === 'development') {
-    return merge(baseConfig, devConfig);
+    return merge(createBaseConfig(env), createDevConfig(env));
   }
   else {
-    return merge(baseConfig, prodConfig);
+    return merge(createBaseConfig(env), createProdConfig(env));
   }
 };


### PR DESCRIPTION
Updated `webpack-config.js` and `api.js` so that setting the `API_URL` now goes through the webpack `--env` flag instead of `process.env`. (This is necessary because the old way doesn't work with `jest-dev-server`. Putting this in a separate pull request so @floriandejonckheere is sure to see the change.) 

Previous way of passing `API_URL`: 
~`$ API_URL=http://localhost:3000/api yarn run dev-server`~

New way of passing `API_URL`:
`$ yarn run dev-server --env.API_URL=http://localhost:3000/api`