### PR TITLE
Fix broken users/UPDATE saga test

### DIFF
--- a/app/modules/users/saga/task/update.test.js
+++ b/app/modules/users/saga/task/update.test.js
@@ -33,6 +33,9 @@ describe(`update`, (): void => {
         [matchers.call.fn(asyncRequests.lib.putAndReturn), dynamic(({ args: [action] }: any, next: any): any => {
           return (action.type === a.API_PATCH) ? null : next();
         })],
+        [matchers.call.fn(asyncRequests.lib.putAndReturn), dynamic(({ args: [action] }: any, next: any): any => {
+          return (action.type === a.FETCH) ? null : next();
+        })],
       ])
       .call(asyncRequests.lib.putAndReturn, actions.apiPatch(dummyId, dummyName, dummyLocale, dummyAlertEmails, undefined, undefined))
       .call(asyncRequests.lib.putAndReturn, actions.fetch(dummyId))


### PR DESCRIPTION
Users/UPDATE saga test was missing a provider for the FETCH action, which caused a timeout during testing:
```
console.warn node_modules/redux-saga-test-plan/lib/expectSaga/index.js:309
[WARNING]: Saga exceeded async timeout of 250ms
```