### PR TITLE
Feature: converting paragraphs into headings

### DIFF
--- a/app/modules/contentItems/actionTypes/reducer.js
+++ b/app/modules/contentItems/actionTypes/reducer.js
@@ -13,6 +13,7 @@ export const ADD_TO_STATE: 'contentItems/ADD_TO_STATE' = 'contentItems/ADD_TO_ST
 export const EDIT_PROPS_FOR_TYPE_IN_STATE: 'contentItems/EDIT_PROPS_FOR_TYPE_IN_STATE' = 'contentItems/EDIT_PROPS_FOR_TYPE_IN_STATE';
 export const SWITCH_EDITING_IN_STATE: 'contentItems/SWITCH_EDITING_IN_STATE' = 'contentItems/SWITCH_EDITING_IN_STATE';
 export const MOVE_IN_STATE: 'contentItems/MOVE_IN_STATE' = 'contentItems/MOVE_IN_STATE';
+export const CONVERT_IN_STATE: 'contentItems/CONVERT_IN_STATE' = 'contentItems/CONVERT_IN_STATE';
 export const REMOVE_FROM_STATE: 'contentItems/REMOVE_FROM_STATE' = 'contentItems/REMOVE_FROM_STATE';
 export const SET_MULTIPLE_IN_STATE: 'contentItems/SET_MULTIPLE_IN_STATE' = 'contentItems/SET_MULTIPLE_IN_STATE';
 
@@ -61,6 +62,16 @@ export type MoveInStateAction = {|
   |},
 |};
 
+export type ConvertInStateAction = {|
+  ...ReducerAction,
+  type: typeof CONVERT_IN_STATE,
+  payload: {|
+    ...$PropertyType<ReducerAction, 'payload'>,
+    id: string,
+    newType: m.ContentItemType,
+  |},
+|};
+
 export type RemoveFromStateAction = {|
   ...ReducerAction,
   type: typeof REMOVE_FROM_STATE,
@@ -84,5 +95,6 @@ export type ContentItemsReducerAction =
   | EditPropsForTypeInStateAction
   | SwitchEditingInStateAction
   | MoveInStateAction
+  | ConvertInStateAction
   | RemoveFromStateAction
   | SetMultipleInStateAction;

--- a/app/modules/contentItems/actions/reducer/convertInState.js
+++ b/app/modules/contentItems/actions/reducer/convertInState.js
@@ -1,0 +1,16 @@
+// @flow
+
+import * as a from '../../actionTypes';
+import * as m from '../../model';
+
+const convertInState = (id: string, newType: m.ContentItemType): a.ConvertInStateAction => {
+  return {
+    type: a.CONVERT_IN_STATE,
+    payload: {
+      id,
+      newType,
+    },
+  };
+};
+
+export default convertInState;

--- a/app/modules/contentItems/actions/reducer/convertInState.test.js
+++ b/app/modules/contentItems/actions/reducer/convertInState.test.js
@@ -1,0 +1,31 @@
+// @flow
+
+import * as a from '../../actionTypes';
+import * as m from '../../model';
+
+import actions from '..';
+
+describe(`convertInState`, (): void => {
+
+  let dummyId: string;
+  let dummyNewType: m.ContentItemType;
+
+  beforeEach((): void => {
+    dummyId = 'dummyId';
+    dummyNewType = m.contentItemTypes.HEADING;
+  });
+
+  it(`returns a contentItems CONVERT_IN_STATE action containing the passed arguments`, (): void => {
+    const expectedAction: a.ConvertInStateAction = {
+      type: a.CONVERT_IN_STATE,
+      payload: {
+        id: dummyId,
+        newType: dummyNewType,
+      },
+    };
+    const actualAction = actions.convertInState(dummyId, dummyNewType);
+
+    expect(actualAction).toStrictEqual(expectedAction);
+  });
+
+});

--- a/app/modules/contentItems/actions/reducer/index.js
+++ b/app/modules/contentItems/actions/reducer/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import addToState from './addToState';
+import convertInState from './convertInState';
 import editPropsForTypeInState from './editPropsForTypeInState';
 import moveInState from './moveInState';
 import removeFromState from './removeFromState';
@@ -9,6 +10,7 @@ import switchEditingInState from './switchEditingInState';
 
 const reducerActions = {
   addToState,
+  convertInState,
   editPropsForTypeInState,
   moveInState,
   removeFromState,

--- a/app/modules/contentItems/reducer/convertInState.js
+++ b/app/modules/contentItems/reducer/convertInState.js
@@ -1,0 +1,82 @@
+// @flow
+
+/* eslint-disable flowtype/no-weak-types */
+
+import _ from 'lodash';
+
+import {
+  InvalidArgumentError,
+  NotYetImplementedError,
+  ObjectNotFoundError,
+  UnsupportedOperationError,
+} from 'errors';
+
+import * as a from '../actionTypes';
+import lib from '../lib';
+import * as m from '../model';
+
+const supportedContentItemTypes = [
+  m.contentItemTypes.HEADING,
+  m.contentItemTypes.PARAGRAPH,
+];
+
+const convertInState = (
+  state: m.ContentItemsState,
+  action: a.ConvertInStateAction,
+): m.ContentItemsState => {
+  const { id, newType } = action.payload;
+
+  // Find the contentItem for the passed id in the state.
+  const contentItemToConvert = state.byId[id];
+  if (contentItemToConvert == null) throw new ObjectNotFoundError('contentItems:contentItem', id);
+
+  // Conversion is only supported for PlainText types.
+  if (
+    !_.includes(m.plainTextContentItemTypes, contentItemToConvert.type)
+    || !_.includes(m.plainTextContentItemTypes, newType)
+  ) {
+    throw new UnsupportedOperationError('Only PlainText contentItems can be converted.');
+  }
+
+  // For now, only HEADING -> PARAGRAPH and PARAGRAPH -> HEADING conversion is supported.
+  if (
+    !_.includes(supportedContentItemTypes, contentItemToConvert.type)
+    || !_.includes(supportedContentItemTypes, newType)
+  ) {
+    throw new NotYetImplementedError();
+  }
+
+  // Verify that the conversion is useful; i.e. that the newType isn't the same as the old type.
+  if (contentItemToConvert.type === newType) {
+    throw new InvalidArgumentError('Cannot convert a contentItem to the same type it already has.');
+  }
+
+  // Verify that the conversion wouldn't result in a HEADING becoming a descendant of a PARAGRAPH.
+  if (newType === m.contentItemTypes.PARAGRAPH) {
+    const allDescendantItems = lib.find.allDescendantItems(contentItemToConvert, state.byId);
+    allDescendantItems.forEach((descendantItem: m.ContentItem): void => {
+      if (descendantItem.type === m.contentItemTypes.HEADING) {
+        throw new UnsupportedOperationError('Invalid conversion: HEADINGs cannot be descendants of PARAGRAPHs.');
+      }
+    });
+  }
+
+  // Convert the contentItem.
+  const convertedContentItem = {
+    ...contentItemToConvert,
+    type: newType,
+    // Note that no further logic is necessary since HEADING and PARAGRAPH are identical,
+    // save for the type. More logic will be necessary when converting, for example, BLOCKQUOTEs.
+    // TODO: implement some sort of contentItem validation that checks if all props are correct
+  };
+
+  return {
+    ...state,
+    byId: {
+      ...state.byId,
+      [id]: convertedContentItem,
+    },
+  };
+};
+
+export default convertInState;

--- a/app/modules/contentItems/reducer/convertInState.test.js
+++ b/app/modules/contentItems/reducer/convertInState.test.js
@@ -1,0 +1,321 @@
+// @flow
+
+import { InvalidArgumentError, NotYetImplementedError, ObjectNotFoundError, UnsupportedOperationError } from 'errors';
+import { dummyContentItemData as dummyData } from 'lib/testResources';
+
+import * as a from '../actionTypes';
+import * as m from '../model';
+
+import reducer from '.';
+
+describe(`CONVERT_IN_STATE`, (): void => {
+
+  let dummyBlockquote333: m.BlockquoteContentItem;
+  let dummyParagraph332: m.ParagraphContentItem;
+  let dummyParagraph331: m.ParagraphContentItem;
+  let dummyHeading33: m.HeadingContentItem;
+  let dummyParagraph32: m.ParagraphContentItem;
+  let dummyParagraph31: m.ParagraphContentItem;
+  let dummyHeading3: m.HeadingContentItem;
+  let dummyParagraph2: m.ParagraphContentItem;
+  let dummyParagraph1: m.ParagraphContentItem;
+  let dummyRoot: m.RootContentItem;
+
+  beforeEach((): void => {
+    dummyBlockquote333 = { ...dummyData.blockquoteContentItem };
+    dummyParagraph332 = { ...dummyData.paragraphContentItem6 };
+    dummyParagraph331 = { ...dummyData.paragraphContentItem5 };
+    dummyHeading33 = { ...dummyData.headingContentItem2 };
+    dummyParagraph32 = { ...dummyData.paragraphContentItem4 };
+    dummyParagraph31 = { ...dummyData.paragraphContentItem3 };
+    dummyHeading3 = { ...dummyData.headingContentItem };
+    dummyParagraph2 = { ...dummyData.paragraphContentItem2 };
+    dummyParagraph1 = { ...dummyData.paragraphContentItem };
+    dummyRoot = { ...dummyData.rootContentItem };
+  });
+
+  it(`converts a PARAGRAPH into a HEADING, when the contentItem for the passed id is a PARAGRAPH and newType is HEADING`, (): void => {
+    const prevState: m.ContentItemsState = {
+      byId: {
+        [dummyRoot.id]: { ...dummyRoot, childItemIds: [dummyParagraph1.id, dummyParagraph2.id, dummyHeading3.id] },
+        [dummyParagraph1.id]: { ...dummyParagraph1 },
+        [dummyParagraph2.id]: { ...dummyParagraph2 },
+        [dummyHeading3.id]: { ...dummyHeading3, subItemIds: [dummyParagraph31.id, dummyParagraph32.id, dummyHeading33.id] },
+        [dummyParagraph31.id]: { ...dummyParagraph31 },
+        [dummyParagraph32.id]: { ...dummyParagraph32 },
+        [dummyHeading33.id]: { ...dummyHeading33, subItemIds: [dummyParagraph331.id, dummyParagraph332.id, dummyBlockquote333.id] },
+        [dummyParagraph331.id]: { ...dummyParagraph331 },
+        [dummyParagraph332.id]: { ...dummyParagraph332 },
+        [dummyBlockquote333.id]: { ...dummyBlockquote333 },
+      },
+    };
+    const convertInStateAction: a.ConvertInStateAction = {
+      type: a.CONVERT_IN_STATE,
+      payload: {
+        id: dummyParagraph2.id,
+        newType: m.contentItemTypes.HEADING,
+      },
+    };
+    const nextState: m.ContentItemsState = {
+      byId: {
+        [dummyRoot.id]: { ...dummyRoot, childItemIds: [dummyParagraph1.id, dummyParagraph2.id, dummyHeading3.id] },
+        [dummyParagraph1.id]: { ...dummyParagraph1 },
+        [dummyParagraph2.id]: { ...dummyParagraph2, type: m.contentItemTypes.HEADING },
+        [dummyHeading3.id]: { ...dummyHeading3, subItemIds: [dummyParagraph31.id, dummyParagraph32.id, dummyHeading33.id] },
+        [dummyParagraph31.id]: { ...dummyParagraph31 },
+        [dummyParagraph32.id]: { ...dummyParagraph32 },
+        [dummyHeading33.id]: { ...dummyHeading33, subItemIds: [dummyParagraph331.id, dummyParagraph332.id, dummyBlockquote333.id] },
+        [dummyParagraph331.id]: { ...dummyParagraph331 },
+        [dummyParagraph332.id]: { ...dummyParagraph332 },
+        [dummyBlockquote333.id]: { ...dummyBlockquote333 },
+      },
+    };
+    const resultState: m.ContentItemsState = reducer(prevState, convertInStateAction);
+
+    expect(resultState).toStrictEqual(nextState);
+    expect(resultState).not.toBe(nextState);
+    expect(resultState.byId).not.toBe(prevState.byId);
+    expect(resultState.byId[dummyRoot.id]).not.toBe(prevState.byId[dummyParagraph2.id]);
+  });
+
+  it(`converts a HEADING into a PARAGRAPH, when the contentItem for the passed id is a HEADING and newType is PARAGRAPH`, (): void => {
+    const prevState: m.ContentItemsState = {
+      byId: {
+        [dummyRoot.id]: { ...dummyRoot, childItemIds: [dummyParagraph1.id, dummyParagraph2.id, dummyHeading3.id] },
+        [dummyParagraph1.id]: { ...dummyParagraph1 },
+        [dummyParagraph2.id]: { ...dummyParagraph2 },
+        [dummyHeading3.id]: { ...dummyHeading3, subItemIds: [dummyParagraph31.id, dummyParagraph32.id, dummyHeading33.id] },
+        [dummyParagraph31.id]: { ...dummyParagraph31 },
+        [dummyParagraph32.id]: { ...dummyParagraph32 },
+        [dummyHeading33.id]: { ...dummyHeading33, subItemIds: [dummyParagraph331.id, dummyParagraph332.id, dummyBlockquote333.id] },
+        [dummyParagraph331.id]: { ...dummyParagraph331 },
+        [dummyParagraph332.id]: { ...dummyParagraph332 },
+        [dummyBlockquote333.id]: { ...dummyBlockquote333 },
+      },
+    };
+    const convertInStateAction: a.ConvertInStateAction = {
+      type: a.CONVERT_IN_STATE,
+      payload: {
+        id: dummyHeading33.id,
+        newType: m.contentItemTypes.PARAGRAPH,
+      },
+    };
+    const nextState: m.ContentItemsState = {
+      byId: {
+        [dummyRoot.id]: { ...dummyRoot, childItemIds: [dummyParagraph1.id, dummyParagraph2.id, dummyHeading3.id] },
+        [dummyParagraph1.id]: { ...dummyParagraph1 },
+        [dummyParagraph2.id]: { ...dummyParagraph2 },
+        [dummyHeading3.id]: { ...dummyHeading3, subItemIds: [dummyParagraph31.id, dummyParagraph32.id, dummyHeading33.id] },
+        [dummyParagraph31.id]: { ...dummyParagraph31 },
+        [dummyParagraph32.id]: { ...dummyParagraph32 },
+        [dummyHeading33.id]: { ...dummyHeading33, subItemIds: [dummyParagraph331.id, dummyParagraph332.id, dummyBlockquote333.id], type: m.contentItemTypes.PARAGRAPH },
+        [dummyParagraph331.id]: { ...dummyParagraph331 },
+        [dummyParagraph332.id]: { ...dummyParagraph332 },
+        [dummyBlockquote333.id]: { ...dummyBlockquote333 },
+      },
+    };
+    const resultState: m.ContentItemsState = reducer(prevState, convertInStateAction);
+
+    expect(resultState).toStrictEqual(nextState);
+    expect(resultState).not.toBe(nextState);
+    expect(resultState.byId).not.toBe(prevState.byId);
+    expect(resultState.byId[dummyRoot.id]).not.toBe(prevState.byId[dummyHeading33.id]);
+  });
+
+  it(`throws an ObjectNotFoundError, when the contentItem for the passed id could not be found`, (): void => {
+    const prevState: m.ContentItemsState = {
+      byId: {
+        [dummyRoot.id]: { ...dummyRoot, childItemIds: [dummyParagraph1.id, dummyParagraph2.id, dummyHeading3.id] },
+        [dummyParagraph1.id]: { ...dummyParagraph1 },
+        [dummyParagraph2.id]: { ...dummyParagraph2 },
+        [dummyHeading3.id]: { ...dummyHeading3, subItemIds: [dummyParagraph31.id, dummyParagraph32.id, dummyHeading33.id] },
+        [dummyParagraph31.id]: { ...dummyParagraph31 },
+        [dummyParagraph32.id]: { ...dummyParagraph32 },
+        [dummyHeading33.id]: { ...dummyHeading33, subItemIds: [dummyParagraph331.id, dummyParagraph332.id, dummyBlockquote333.id] },
+        [dummyParagraph331.id]: { ...dummyParagraph331 },
+        [dummyParagraph332.id]: { ...dummyParagraph332 },
+        [dummyBlockquote333.id]: { ...dummyBlockquote333 },
+      },
+    };
+    const convertInStateAction: a.ConvertInStateAction = {
+      type: a.CONVERT_IN_STATE,
+      payload: {
+        id: 'invalidId',
+        newType: m.contentItemTypes.HEADING,
+      },
+    };
+
+    expect((): void => {
+      reducer(prevState, convertInStateAction);
+    }).toThrow(ObjectNotFoundError);
+  });
+
+  it(`throws an UnsupportedOperationError, when the contentItem for the passed id is not a PlainText contentItem`, (): void => {
+    const prevState: m.ContentItemsState = {
+      byId: {
+        [dummyRoot.id]: { ...dummyRoot, childItemIds: [dummyParagraph1.id, dummyParagraph2.id, dummyHeading3.id] },
+        [dummyParagraph1.id]: { ...dummyParagraph1 },
+        [dummyParagraph2.id]: { ...dummyParagraph2 },
+        [dummyHeading3.id]: { ...dummyHeading3, subItemIds: [dummyParagraph31.id, dummyParagraph32.id, dummyHeading33.id] },
+        [dummyParagraph31.id]: { ...dummyParagraph31 },
+        [dummyParagraph32.id]: { ...dummyParagraph32 },
+        [dummyHeading33.id]: { ...dummyHeading33, subItemIds: [dummyParagraph331.id, dummyParagraph332.id, dummyBlockquote333.id] },
+        [dummyParagraph331.id]: { ...dummyParagraph331 },
+        [dummyParagraph332.id]: { ...dummyParagraph332 },
+        [dummyBlockquote333.id]: { ...dummyBlockquote333 },
+      },
+    };
+    const convertInStateAction: a.ConvertInStateAction = {
+      type: a.CONVERT_IN_STATE,
+      payload: {
+        id: dummyRoot.id,
+        newType: m.contentItemTypes.HEADING,
+      },
+    };
+
+    expect((): void => {
+      reducer(prevState, convertInStateAction);
+    }).toThrow(UnsupportedOperationError);
+  });
+
+  it(`throws an InvalidArgumentError, when the contentItem for the passed id already has newType as its type`, (): void => {
+    const prevState: m.ContentItemsState = {
+      byId: {
+        [dummyRoot.id]: { ...dummyRoot, childItemIds: [dummyParagraph1.id, dummyParagraph2.id, dummyHeading3.id] },
+        [dummyParagraph1.id]: { ...dummyParagraph1 },
+        [dummyParagraph2.id]: { ...dummyParagraph2 },
+        [dummyHeading3.id]: { ...dummyHeading3, subItemIds: [dummyParagraph31.id, dummyParagraph32.id, dummyHeading33.id] },
+        [dummyParagraph31.id]: { ...dummyParagraph31 },
+        [dummyParagraph32.id]: { ...dummyParagraph32 },
+        [dummyHeading33.id]: { ...dummyHeading33, subItemIds: [dummyParagraph331.id, dummyParagraph332.id, dummyBlockquote333.id] },
+        [dummyParagraph331.id]: { ...dummyParagraph331 },
+        [dummyParagraph332.id]: { ...dummyParagraph332 },
+        [dummyBlockquote333.id]: { ...dummyBlockquote333 },
+      },
+    };
+    const convertInStateAction: a.ConvertInStateAction = {
+      type: a.CONVERT_IN_STATE,
+      payload: {
+        id: dummyParagraph2.id,
+        newType: m.contentItemTypes.PARAGRAPH,
+      },
+    };
+
+    expect((): void => {
+      reducer(prevState, convertInStateAction);
+    }).toThrow(InvalidArgumentError);
+  });
+
+  it(`throws an UnsupportedOperationError, when the newType is not a PlainText type`, (): void => {
+    const prevState: m.ContentItemsState = {
+      byId: {
+        [dummyRoot.id]: { ...dummyRoot, childItemIds: [dummyParagraph1.id, dummyParagraph2.id, dummyHeading3.id] },
+        [dummyParagraph1.id]: { ...dummyParagraph1 },
+        [dummyParagraph2.id]: { ...dummyParagraph2 },
+        [dummyHeading3.id]: { ...dummyHeading3, subItemIds: [dummyParagraph31.id, dummyParagraph32.id, dummyHeading33.id] },
+        [dummyParagraph31.id]: { ...dummyParagraph31 },
+        [dummyParagraph32.id]: { ...dummyParagraph32 },
+        [dummyHeading33.id]: { ...dummyHeading33, subItemIds: [dummyParagraph331.id, dummyParagraph332.id, dummyBlockquote333.id] },
+        [dummyParagraph331.id]: { ...dummyParagraph331 },
+        [dummyParagraph332.id]: { ...dummyParagraph332 },
+        [dummyBlockquote333.id]: { ...dummyBlockquote333 },
+      },
+    };
+    const convertInStateAction: a.ConvertInStateAction = {
+      type: a.CONVERT_IN_STATE,
+      payload: {
+        id: dummyParagraph2.id,
+        newType: m.contentItemTypes.IMAGE,
+      },
+    };
+
+    expect((): void => {
+      reducer(prevState, convertInStateAction);
+    }).toThrow(UnsupportedOperationError);
+  });
+
+  it(`throws an UnsupportedOperationError, when attempting to convert a HEADING that has other HEADINGS in its descendants to a PARAGRAPH`, (): void => {
+    const prevState: m.ContentItemsState = {
+      byId: {
+        [dummyRoot.id]: { ...dummyRoot, childItemIds: [dummyParagraph1.id, dummyParagraph2.id, dummyHeading3.id] },
+        [dummyParagraph1.id]: { ...dummyParagraph1 },
+        [dummyParagraph2.id]: { ...dummyParagraph2 },
+        [dummyHeading3.id]: { ...dummyHeading3, subItemIds: [dummyParagraph31.id, dummyParagraph32.id, dummyHeading33.id] },
+        [dummyParagraph31.id]: { ...dummyParagraph31 },
+        [dummyParagraph32.id]: { ...dummyParagraph32 },
+        [dummyHeading33.id]: { ...dummyHeading33, subItemIds: [dummyParagraph331.id, dummyParagraph332.id, dummyBlockquote333.id] },
+        [dummyParagraph331.id]: { ...dummyParagraph331 },
+        [dummyParagraph332.id]: { ...dummyParagraph332 },
+        [dummyBlockquote333.id]: { ...dummyBlockquote333 },
+      },
+    };
+    const convertInStateAction: a.ConvertInStateAction = {
+      type: a.CONVERT_IN_STATE,
+      payload: {
+        id: dummyHeading3.id,
+        newType: m.contentItemTypes.PARAGRAPH,
+      },
+    };
+
+    expect((): void => {
+      reducer(prevState, convertInStateAction);
+    }).toThrow(UnsupportedOperationError);
+  });
+
+  it(`temporarily throws a NotYetImplementedError, when the contentItem for the passed id has a PlainText type different from HEADING or PARAGRAPH`, (): void => {
+    const prevState: m.ContentItemsState = {
+      byId: {
+        [dummyRoot.id]: { ...dummyRoot, childItemIds: [dummyParagraph1.id, dummyParagraph2.id, dummyHeading3.id] },
+        [dummyParagraph1.id]: { ...dummyParagraph1 },
+        [dummyParagraph2.id]: { ...dummyParagraph2 },
+        [dummyHeading3.id]: { ...dummyHeading3, subItemIds: [dummyParagraph31.id, dummyParagraph32.id, dummyHeading33.id] },
+        [dummyParagraph31.id]: { ...dummyParagraph31 },
+        [dummyParagraph32.id]: { ...dummyParagraph32 },
+        [dummyHeading33.id]: { ...dummyHeading33, subItemIds: [dummyParagraph331.id, dummyParagraph332.id, dummyBlockquote333.id] },
+        [dummyParagraph331.id]: { ...dummyParagraph331 },
+        [dummyParagraph332.id]: { ...dummyParagraph332 },
+        [dummyBlockquote333.id]: { ...dummyBlockquote333 },
+      },
+    };
+    const convertInStateAction: a.ConvertInStateAction = {
+      type: a.CONVERT_IN_STATE,
+      payload: {
+        id: dummyBlockquote333.id,
+        newType: m.contentItemTypes.PARAGRAPH,
+      },
+    };
+
+    expect((): void => {
+      reducer(prevState, convertInStateAction);
+    }).toThrow(NotYetImplementedError);
+  });
+
+  it(`temporarily throws a NotYetImplementedError, when the newType is a PlainText type different from HEADING or PARAGRAPH`, (): void => {
+    const prevState: m.ContentItemsState = {
+      byId: {
+        [dummyRoot.id]: { ...dummyRoot, childItemIds: [dummyParagraph1.id, dummyParagraph2.id, dummyHeading3.id] },
+        [dummyParagraph1.id]: { ...dummyParagraph1 },
+        [dummyParagraph2.id]: { ...dummyParagraph2 },
+        [dummyHeading3.id]: { ...dummyHeading3, subItemIds: [dummyParagraph31.id, dummyParagraph32.id, dummyHeading33.id] },
+        [dummyParagraph31.id]: { ...dummyParagraph31 },
+        [dummyParagraph32.id]: { ...dummyParagraph32 },
+        [dummyHeading33.id]: { ...dummyHeading33, subItemIds: [dummyParagraph331.id, dummyParagraph332.id, dummyBlockquote333.id] },
+        [dummyParagraph331.id]: { ...dummyParagraph331 },
+        [dummyParagraph332.id]: { ...dummyParagraph332 },
+        [dummyBlockquote333.id]: { ...dummyBlockquote333 },
+      },
+    };
+    const convertInStateAction: a.ConvertInStateAction = {
+      type: a.CONVERT_IN_STATE,
+      payload: {
+        id: dummyParagraph2.id,
+        newType: m.contentItemTypes.BLOCKQUOTE,
+      },
+    };
+
+    expect((): void => {
+      reducer(prevState, convertInStateAction);
+    }).toThrow(NotYetImplementedError);
+  });
+
+});

--- a/app/modules/contentItems/reducer/index.js
+++ b/app/modules/contentItems/reducer/index.js
@@ -4,6 +4,7 @@ import * as a from '../actionTypes';
 import * as m from '../model';
 
 import addToState from './addToState';
+import convertInState from './convertInState';
 import editPropsForTypeInState from './editPropsForTypeInState';
 import switchEditingInState from './switchEditingInState';
 import moveInState from './moveInState';
@@ -21,6 +22,8 @@ const reducer = (
   switch (action.type) {
     case a.ADD_TO_STATE:
       return addToState(state, action);
+    case a.CONVERT_IN_STATE:
+      return convertInState(state, action);
     case a.EDIT_PROPS_FOR_TYPE_IN_STATE:
       return editPropsForTypeInState(state, action);
     case a.SWITCH_EDITING_IN_STATE:

--- a/app/modules/contentItems/saga/task/edit.js
+++ b/app/modules/contentItems/saga/task/edit.js
@@ -1,20 +1,89 @@
 // @flow
 
+import _ from 'lodash';
 import { type Saga } from 'redux-saga';
-import { put, select } from 'redux-saga/effects';
+import { call, put, select } from 'redux-saga/effects';
 
-import { ObjectNotFoundError } from 'errors';
+import { CorruptedInternalStateError, ObjectNotFoundError } from 'errors';
+import asyncRequests from 'modules/asyncRequests';
 
 import * as a from '../../actionTypes';
 import actions from '../../actions';
+import lib from '../../lib';
+import * as m from '../../model';
 import selectors from '../../selectors';
+
+const { putAndReturn } = asyncRequests.lib;
+
+const findNextParagraphs = function* (
+  context: m.ExtendedVerticalContext,
+): Saga<$ReadOnlyArray<m.ParagraphContentItem>> {
+  const nextParagraphs = [];
+  let currentSiblingItem: ?m.ContentItem;
+
+  for (let i: number = context.indexInSiblingItems + 1; i < context.siblingItemIds.length; i += 1) {
+    currentSiblingItem = yield select(selectors.getById, { id: context.siblingItemIds[i] });
+
+    if (currentSiblingItem != null && currentSiblingItem.type === m.contentItemTypes.PARAGRAPH) {
+      nextParagraphs.push(currentSiblingItem);
+    }
+    else {
+      break;
+    }
+  }
+
+  return nextParagraphs;
+};
+
+const convertParagraphIntoHeading = function* (contentItem: m.ParagraphContentItem): Saga<void> {
+  // Get contentItem context data.
+  const contentItemsById = yield select(selectors.getAllById);
+  const context = lib.find.extendedVerticalContext(contentItem, contentItemsById);
+  if (context == null) throw new CorruptedInternalStateError('Corrupted contentItemsById: could not find context for PARAGRAPH contentItem.');
+
+  // First, make sure the conversion doesn't result in invalid state;
+  // i.e. make sure that the new HEADING is not followed by sibling PARAGRAPHS.
+  // Do this by moving all sibling PARAGRAPHs to the new HEADINGs subItems (similar to what would
+  // happen in a more conventional editor, where if you insert a heading above existing paragraphs,
+  // those paragraphs automatically 'belong' to that heading).
+  const nextParagraphs = yield call(findNextParagraphs, context);
+  const moveContext: m.VerticalContext = {
+    contextType: m.contextTypes.SUPER,
+    contextItemId: contentItem.id,
+    indexInSiblingItems: contentItem.subItemIds.length,
+  };
+  // Note: do this in reverse so we can use the same moveContext every time.
+  for (let i: number = nextParagraphs.length - 1; i >= 0; i -= 1) {
+    yield call(putAndReturn, actions.move(
+      nextParagraphs[i].id,
+      moveContext,
+    ));
+  }
+
+  // Convert the contentItem.
+  yield put(actions.convertInState(contentItem.id, m.contentItemTypes.HEADING));
+};
 
 const edit = function* (action: a.EditAction): Saga<void> {
   const { id, propsForType } = action.payload;
-  const contentItemToEdit = yield select(selectors.getById, { id });
+  const newPropsForType = { ...propsForType };
+  let contentItemToEdit: ?m.ContentItem = yield select(selectors.getById, { id });
   if (contentItemToEdit == null) throw new ObjectNotFoundError('contentItems:contentItem', id);
 
-  yield put(actions.editPropsForTypeInState(contentItemToEdit, propsForType));
+  // Enable PARAGRAPH -> HEADING conversion by typing '# ' at the start of the text field.
+  if (
+    contentItemToEdit.type === m.contentItemTypes.PARAGRAPH
+    && propsForType.text != null && _.startsWith(propsForType.text, '# ')
+  ) {
+    // Convert the contentItem.
+    yield call(convertParagraphIntoHeading, contentItemToEdit);
+    // Get the updated contentItem from the state.
+    contentItemToEdit = yield select(selectors.getById, { id });
+    // Remove the '# ' prefix from the passed text prop.
+    newPropsForType.text = propsForType.text.substring(2);
+  }
+
+  yield put(actions.editPropsForTypeInState(contentItemToEdit, newPropsForType));
 };
 
 export default edit;

--- a/app/modules/contentItems/saga/task/edit.test.js
+++ b/app/modules/contentItems/saga/task/edit.test.js
@@ -1,11 +1,16 @@
 // @flow
 
+import _ from 'lodash';
 import { expectSaga } from 'redux-saga-test-plan';
+import * as matchers from 'redux-saga-test-plan/matchers';
+import { dynamic } from 'redux-saga-test-plan/providers';
 
-import { ObjectNotFoundError } from 'errors';
+import { CorruptedInternalStateError, ObjectNotFoundError } from 'errors';
 import { dummyContentItemData as dummyData } from 'lib/testResources';
+import asyncRequests from 'modules/asyncRequests';
 
 import actions from '../../actions';
+import * as a from '../../actionTypes';
 import * as m from '../../model';
 
 import { sagas } from '..';
@@ -14,7 +19,11 @@ describe(`edit`, (): void => {
 
   let dummyEditedText: string;
 
+  let dummyHeading2: m.HeadingContentItem;
+  let dummyHeading14: m.HeadingContentItem;
+  let dummyParagraph13: m.ParagraphContentItem;
   let dummyParagraph12: m.ParagraphContentItem;
+  let dummyParagraph111: m.ParagraphContentItem;
   let dummyParagraph11: m.ParagraphContentItem;
   let dummyHeading1: m.HeadingContentItem;
   let dummyRoot: m.RootContentItem;
@@ -25,21 +34,29 @@ describe(`edit`, (): void => {
   beforeEach((): void => {
     dummyEditedText = 'This text has been edited.';
 
-    dummyParagraph12 = { ...dummyData.paragraphContentItem2 };
-    dummyParagraph11 = { ...dummyData.paragraphContentItem };
+    dummyHeading2 = { ...dummyData.headingContentItem3 };
+    dummyHeading14 = { ...dummyData.headingContentItem2 };
+    dummyParagraph13 = { ...dummyData.paragraphContentItem4 };
+    dummyParagraph12 = { ...dummyData.paragraphContentItem3 };
+    dummyParagraph111 = { ...dummyData.paragraphContentItem2 };
+    dummyParagraph11 = { ...dummyData.paragraphContentItem, subItemIds: [dummyParagraph111.id] };
     dummyHeading1 = {
       ...dummyData.headingContentItem,
-      subItemIds: [dummyParagraph11.id, dummyParagraph12.id],
+      subItemIds: [dummyParagraph11.id, dummyParagraph12.id, dummyParagraph13.id, dummyHeading14.id],
     };
     dummyRoot = {
       ...dummyData.rootContentItem,
-      childItemIds: [dummyHeading1.id],
+      childItemIds: [dummyHeading1.id, dummyHeading2.id],
     };
     dummyContentItemsById = {
       [dummyRoot.id]: dummyRoot,
       [dummyHeading1.id]: dummyHeading1,
       [dummyParagraph11.id]: dummyParagraph11,
+      [dummyParagraph111.id]: dummyParagraph111,
       [dummyParagraph12.id]: dummyParagraph12,
+      [dummyParagraph13.id]: dummyParagraph13,
+      [dummyHeading14.id]: dummyHeading14,
+      [dummyHeading2.id]: dummyHeading2,
     };
     dummyContentItemsState = {
       byId: dummyContentItemsById,
@@ -56,7 +73,56 @@ describe(`edit`, (): void => {
 
     return expectSaga(sagas.edit, dummyAction)
       .withState(dummyState)
+      .provide([
+        [matchers.call.fn(asyncRequests.lib.putAndReturn), dynamic(({ args: [action] }: any, next: any): any => {
+          return (action.type === a.MOVE) ? null : next();
+        })],
+      ])
       .put(actions.editPropsForTypeInState(dummyParagraph11, { text: dummyEditedText }))
+      .run();
+  });
+
+  it(`converts a PARAGRAPH into a HEADING, when the PARAGRAPH's edited text prop starts with '# '`, (): void => {
+    const dummyAction = actions.edit(dummyParagraph12.id, { text: `# ${dummyEditedText}` });
+
+    return expectSaga(sagas.edit, dummyAction)
+      .withState(dummyState)
+      .provide([
+        [matchers.call.fn(asyncRequests.lib.putAndReturn), dynamic(({ args: [action] }: any, next: any): any => {
+          return (action.type === a.MOVE) ? null : next();
+        })],
+      ])
+      .put(actions.convertInState(dummyParagraph12.id, m.contentItemTypes.HEADING))
+      .put(actions.editPropsForTypeInState(dummyParagraph12, { text: dummyEditedText }))
+      .run();
+  });
+
+  it(`moves any subsequent sibling PARAGRAPHS to the edited item's subItems, when converting a PARAGRAPH into a HEADING`, (): void => {
+    const dummyAction = actions.edit(dummyParagraph11.id, { text: `# ${dummyEditedText}` });
+
+    return expectSaga(sagas.edit, dummyAction)
+      .withState(dummyState)
+      .provide([
+        [matchers.call.fn(asyncRequests.lib.putAndReturn), dynamic(({ args: [action] }: any, next: any): any => {
+          return (action.type === a.MOVE) ? null : next();
+        })],
+      ])
+      .call(asyncRequests.lib.putAndReturn, actions.move(
+        dummyParagraph13.id,
+        {
+          contextType: m.contextTypes.SUPER,
+          contextItemId: dummyParagraph11.id,
+          indexInSiblingItems: 1,
+        },
+      ))
+      .call(asyncRequests.lib.putAndReturn, actions.move(
+        dummyParagraph12.id,
+        {
+          contextType: m.contextTypes.SUPER,
+          contextItemId: dummyParagraph11.id,
+          indexInSiblingItems: 1,
+        },
+      ))
       .run();
   });
 
@@ -68,8 +134,31 @@ describe(`edit`, (): void => {
     await expect(
       expectSaga(sagas.edit, dummyAction)
         .withState(dummyState)
+        .provide([
+          [matchers.call.fn(asyncRequests.lib.putAndReturn), dynamic(({ args: [action] }: any, next: any): any => {
+            return (action.type === a.MOVE) ? null : next();
+          })],
+        ])
         .run(),
     ).rejects.toBeInstanceOf(ObjectNotFoundError);
+  });
+
+  it(`throws a CorruptedInternalStateError, when the passed contentItemsById structure is corrupted`, async (): Promise<void> => {
+    dummyHeading1.subItemIds = _.without(dummyHeading1.subItemIds, dummyParagraph12.id);
+    const dummyAction = actions.edit(dummyParagraph12.id, { text: `# ${dummyEditedText}` });
+
+    // Suppress console.error from redux-saga $FlowFixMe
+    console.error = jest.fn();
+    await expect(
+      expectSaga(sagas.edit, dummyAction)
+        .withState(dummyState)
+        .provide([
+          [matchers.call.fn(asyncRequests.lib.putAndReturn), dynamic(({ args: [action] }: any, next: any): any => {
+            return (action.type === a.MOVE) ? null : next();
+          })],
+        ])
+        .run(),
+    ).rejects.toBeInstanceOf(CorruptedInternalStateError);
   });
 
 });


### PR DESCRIPTION
Paragraphs can now be converted into headings by inserting '# ' (note the space) at the start of the text field.
(Note: headings cannot currently be converted back into paragraphs. However, this limitation can be worked around by inserting a new paragraph and cutting/pasting the heading's text.)